### PR TITLE
feat: added linkedin to readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ PolyBuys/
 - [Taye Staats](https://www.linkedin.com/) - Developer
 - [Cole Hackman](https://www.linkedin.com/) - Developer
 - [Lorinc Heutchy](https://www.linkedin.com/) - Developer
-- [Haixin Huang](https://www.linkedin.com/) - Developer
+- [Haixin Huang](https://www.linkedin.com/in/haixin-huang-116799200) - Developer
 - [Domenic Federico](https://www.linkedin.com/) - Developer
 - [Omar Garcia](https://www.linkedin.com/) - Developer
 


### PR DESCRIPTION
## Developer: Haixin Huang

## Summary
Added my LinkedIn to the README.md under Teams section. ([POLY-5](https://linear.app/poly-buys/issue/POLY-5/add-your-linkedin-to-the-readmemd-under-the-teams))

## Modifications
Made a change to README.md file.

## Testing Considerations
Navigate to the README.md file on Github and verify that the link goes to my LinkedIn profile instead of the general LinkedIn feed page.

## Checklist
- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows conventions
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

## Screenshots / Demos
(if UI or visible behavior)
<img width="951" height="32" alt="image" src="https://github.com/user-attachments/assets/467419f0-5e4a-49b6-bf9b-6a3b48c17e5e" />
<img width="1919" height="921" alt="image" src="https://github.com/user-attachments/assets/2f3de2f0-e2d5-43e2-b04b-4332e29c4dfd" />
