### PR TITLE
feat: add report schema and submission endpoint (POLY-19)

### DIFF
--- a/backend/convex/__tests__/reports.test.ts
+++ b/backend/convex/__tests__/reports.test.ts
@@ -27,7 +27,6 @@ describe('Reports mutations', () => {
       return await ctx.db.insert('users', {
         email,
         name: 'Test User',
-        emailVerified: true,
         createdAt: Date.now(),
       });
     });
@@ -303,5 +302,318 @@ describe('Reports mutations', () => {
     });
 
     expect(report?.notes).toBe(validNotes);
+  });
+
+  // Auto-hide functionality tests
+  it('listing auto-hidden after 3rd unique report', async () => {
+    const t = convexTest(schema as any, modules);
+
+    // Create 3 different users
+    await createTestUser(t, 'reporter1@calpoly.edu');
+    await createTestUser(t, 'reporter2@calpoly.edu');
+    await createTestUser(t, 'reporter3@calpoly.edu');
+
+    const listingId = await createTestListing(t, 'seller-id');
+
+    // Report from 3 different users
+    const asUser1 = t.withIdentity({
+      name: 'Reporter1',
+      subject: 'reporter1-subject',
+      email: 'reporter1@calpoly.edu',
+    });
+    await asUser1.mutation(api.reports.createReport, {
+      targetId: listingId,
+      targetType: 'listing',
+      reason: 'scam',
+    });
+
+    const asUser2 = t.withIdentity({
+      name: 'Reporter2',
+      subject: 'reporter2-subject',
+      email: 'reporter2@calpoly.edu',
+    });
+    await asUser2.mutation(api.reports.createReport, {
+      targetId: listingId,
+      targetType: 'listing',
+      reason: 'scam',
+    });
+
+    const asUser3 = t.withIdentity({
+      name: 'Reporter3',
+      subject: 'reporter3-subject',
+      email: 'reporter3@calpoly.edu',
+    });
+    await asUser3.mutation(api.reports.createReport, {
+      targetId: listingId,
+      targetType: 'listing',
+      reason: 'scam',
+    });
+
+    // Check that listing is now hidden
+    const listing = await t.run(async (ctx: any) => {
+      return await ctx.db.get(listingId);
+    });
+
+    expect(listing?.isHidden).toBe(true);
+    expect(listing?.hiddenReason).toBe('auto_moderation');
+    expect(typeof listing?.hiddenAt).toBe('number');
+  });
+
+  it('listing NOT hidden after 2 unique reports (below threshold)', async () => {
+    const t = convexTest(schema as any, modules);
+
+    await createTestUser(t, 'reporter1@calpoly.edu');
+    await createTestUser(t, 'reporter2@calpoly.edu');
+
+    const listingId = await createTestListing(t, 'seller-id');
+
+    const asUser1 = t.withIdentity({
+      name: 'Reporter1',
+      subject: 'reporter1-subject',
+      email: 'reporter1@calpoly.edu',
+    });
+    await asUser1.mutation(api.reports.createReport, {
+      targetId: listingId,
+      targetType: 'listing',
+      reason: 'spam',
+    });
+
+    const asUser2 = t.withIdentity({
+      name: 'Reporter2',
+      subject: 'reporter2-subject',
+      email: 'reporter2@calpoly.edu',
+    });
+    await asUser2.mutation(api.reports.createReport, {
+      targetId: listingId,
+      targetType: 'listing',
+      reason: 'spam',
+    });
+
+    // Check that listing is NOT hidden
+    const listing = await t.run(async (ctx: any) => {
+      return await ctx.db.get(listingId);
+    });
+
+    expect(listing?.isHidden).toBeUndefined();
+  });
+
+  it('profile auto-hidden after 3rd unique report', async () => {
+    const t = convexTest(schema as any, modules);
+
+    await createTestUser(t, 'reporter1@calpoly.edu');
+    await createTestUser(t, 'reporter2@calpoly.edu');
+    await createTestUser(t, 'reporter3@calpoly.edu');
+
+    const profileId = await createTestProfile(t, 'profile-user-id');
+
+    const asUser1 = t.withIdentity({
+      name: 'Reporter1',
+      subject: 'reporter1-subject',
+      email: 'reporter1@calpoly.edu',
+    });
+    await asUser1.mutation(api.reports.createReport, {
+      targetId: profileId,
+      targetType: 'profile',
+      reason: 'inappropriate',
+    });
+
+    const asUser2 = t.withIdentity({
+      name: 'Reporter2',
+      subject: 'reporter2-subject',
+      email: 'reporter2@calpoly.edu',
+    });
+    await asUser2.mutation(api.reports.createReport, {
+      targetId: profileId,
+      targetType: 'profile',
+      reason: 'inappropriate',
+    });
+
+    const asUser3 = t.withIdentity({
+      name: 'Reporter3',
+      subject: 'reporter3-subject',
+      email: 'reporter3@calpoly.edu',
+    });
+    await asUser3.mutation(api.reports.createReport, {
+      targetId: profileId,
+      targetType: 'profile',
+      reason: 'inappropriate',
+    });
+
+    // Check that profile is now hidden
+    const profile = await t.run(async (ctx: any) => {
+      return await ctx.db.get(profileId);
+    });
+
+    expect(profile?.isHidden).toBe(true);
+    expect(profile?.hiddenReason).toBe('auto_moderation');
+    expect(typeof profile?.hiddenAt).toBe('number');
+  });
+
+  it('hidden listing excluded from getListings query', async () => {
+    const t = convexTest(schema as any, modules);
+
+    // Create a hidden listing
+    const seller = t.withIdentity({ name: 'Seller', subject: 'seller-id' });
+    const listingId = await seller.mutation(api.listings.createListing, {
+      title: 'Test Listing',
+      description: 'A test listing',
+      price: 50,
+      sellerEmail: 'seller@calpoly.edu',
+      images: ['https://example.com/image.png'],
+      condition: 'used',
+      category: 'textbooks',
+    });
+
+    // Manually mark as hidden
+    await t.run(async (ctx: any) => {
+      await ctx.db.patch(listingId, {
+        isHidden: true,
+        hiddenAt: Date.now(),
+        hiddenReason: 'auto_moderation',
+      });
+    });
+
+    // Query listings
+    const listings = await t.query(api.listings.getListings, {});
+
+    // Hidden listing should not be in the results
+    expect(listings.find((l: any) => l._id === listingId)).toBeUndefined();
+  });
+
+  it('owner can view their own hidden listing via getListing', async () => {
+    const t = convexTest(schema as any, modules);
+
+    // Create a listing
+    const seller = t.withIdentity({ name: 'Seller', subject: 'seller-id' });
+    const listingId = await seller.mutation(api.listings.createListing, {
+      title: 'Test Listing',
+      description: 'A test listing',
+      price: 50,
+      sellerEmail: 'seller@calpoly.edu',
+      images: ['https://example.com/image.png'],
+      condition: 'used',
+      category: 'textbooks',
+    });
+
+    // Mark as hidden
+    await t.run(async (ctx: any) => {
+      await ctx.db.patch(listingId, {
+        isHidden: true,
+        hiddenAt: Date.now(),
+        hiddenReason: 'auto_moderation',
+      });
+    });
+
+    // Owner should still be able to see it
+    const listing = await seller.query(api.listings.getListing, { id: listingId });
+    expect(listing).not.toBeNull();
+    expect(listing?.isHidden).toBe(true);
+  });
+
+  it('non-owner cannot view hidden listing via getListing', async () => {
+    const t = convexTest(schema as any, modules);
+
+    // Create a listing
+    const seller = t.withIdentity({ name: 'Seller', subject: 'seller-id' });
+    const listingId = await seller.mutation(api.listings.createListing, {
+      title: 'Test Listing',
+      description: 'A test listing',
+      price: 50,
+      sellerEmail: 'seller@calpoly.edu',
+      images: ['https://example.com/image.png'],
+      condition: 'used',
+      category: 'textbooks',
+    });
+
+    // Mark as hidden
+    await t.run(async (ctx: any) => {
+      await ctx.db.patch(listingId, {
+        isHidden: true,
+        hiddenAt: Date.now(),
+        hiddenReason: 'auto_moderation',
+      });
+    });
+
+    // Different user should get null
+    const otherUser = t.withIdentity({ name: 'Other', subject: 'other-id' });
+    const listing = await otherUser.query(api.listings.getListing, { id: listingId });
+    expect(listing).toBeNull();
+  });
+
+  it("getMyHiddenListings returns only user's hidden listings", async () => {
+    const t = convexTest(schema as any, modules);
+
+    const seller = t.withIdentity({ name: 'Seller', subject: 'seller-id' });
+
+    // Create 2 listings
+    const listingId1 = await seller.mutation(api.listings.createListing, {
+      title: 'Test Listing 1',
+      description: 'First listing',
+      price: 50,
+      sellerEmail: 'seller@calpoly.edu',
+      images: ['https://example.com/image.png'],
+      condition: 'used',
+      category: 'textbooks',
+    });
+
+    await seller.mutation(api.listings.createListing, {
+      title: 'Test Listing 2',
+      description: 'Second listing',
+      price: 60,
+      sellerEmail: 'seller@calpoly.edu',
+      images: ['https://example.com/image.png'],
+      condition: 'new',
+      category: 'electronics',
+    });
+
+    // Hide first listing
+    await t.run(async (ctx: any) => {
+      await ctx.db.patch(listingId1, {
+        isHidden: true,
+        hiddenAt: Date.now(),
+        hiddenReason: 'auto_moderation',
+      });
+    });
+
+    // Query hidden listings
+    const hiddenListings = await seller.query(api.listings.getMyHiddenListings, {});
+
+    expect(hiddenListings.length).toBe(1);
+    expect(hiddenListings[0]._id).toBe(listingId1);
+    expect(hiddenListings[0].isHidden).toBe(true);
+  });
+
+  it('hidden content excluded from searchAndFilterListings', async () => {
+    const t = convexTest(schema as any, modules);
+
+    const seller = t.withIdentity({ name: 'Seller', subject: 'seller-id' });
+
+    // Create a listing
+    const listingId = await seller.mutation(api.listings.createListing, {
+      title: 'Test Textbook',
+      description: 'A test textbook',
+      price: 50,
+      sellerEmail: 'seller@calpoly.edu',
+      images: ['https://example.com/image.png'],
+      condition: 'used',
+      category: 'textbooks',
+    });
+
+    // Hide it
+    await t.run(async (ctx: any) => {
+      await ctx.db.patch(listingId, {
+        isHidden: true,
+        hiddenAt: Date.now(),
+        hiddenReason: 'auto_moderation',
+      });
+    });
+
+    // Search for it
+    const results = await t.query(api.listings.searchAndFilterListings, {
+      filters: { category: 'textbooks' },
+    });
+
+    // Should not be in results
+    expect(results.items.find((l: any) => l._id === listingId)).toBeUndefined();
   });
 });

--- a/backend/convex/__tests__/reports.test.ts
+++ b/backend/convex/__tests__/reports.test.ts
@@ -1,0 +1,307 @@
+// backend/convex/__tests__/reports.test.ts
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { convexTest } from 'convex-test';
+import schema from '../schema';
+import { api } from '../_generated/api';
+import * as reportsModule from '../reports';
+import * as listingsModule from '../listings';
+import * as profilesModule from '../profiles';
+import * as apiModule from '../_generated/api';
+import * as serverModule from '../_generated/server';
+
+// Import all Convex function modules so convex-test can run them
+const modules = {
+  '../reports.ts': () => Promise.resolve(reportsModule),
+  '../listings.ts': () => Promise.resolve(listingsModule),
+  '../profiles.ts': () => Promise.resolve(profilesModule),
+  '../_generated/api.ts': () => Promise.resolve(apiModule),
+  '../_generated/server.ts': () => Promise.resolve(serverModule),
+} as any;
+
+describe('Reports mutations', () => {
+  // Helper: create a test user
+  const createTestUser = async (t: any, email: string) => {
+    return await t.run(async (ctx: any) => {
+      return await ctx.db.insert('users', {
+        email,
+        name: 'Test User',
+        emailVerified: true,
+        createdAt: Date.now(),
+      });
+    });
+  };
+
+  // Helper: create a test listing
+  const createTestListing = async (t: any, sellerId: string) => {
+    return await t.run(async (ctx: any) => {
+      return await ctx.db.insert('listings', {
+        title: 'Test Listing',
+        description: 'A test listing',
+        price: 50,
+        sellerEmail: 'seller@calpoly.edu',
+        sellerId,
+        images: ['https://example.com/image.png'],
+        condition: 'used',
+        category: 'textbooks',
+        status: 'active',
+        createdAt: Date.now(),
+        postedOn: Date.now(),
+      });
+    });
+  };
+
+  // Helper: create a test profile
+  const createTestProfile = async (t: any, userId: string) => {
+    return await t.run(async (ctx: any) => {
+      return await ctx.db.insert('profiles', {
+        userId,
+        name: 'Test Profile',
+        email: 'profile@calpoly.edu',
+        joinDate: Date.now(),
+        major: 'Computer Science',
+        year: 2024,
+        rating: 5,
+        review_count: 0,
+      });
+    });
+  };
+
+  it('createReport succeeds with valid listing report', async () => {
+    const t = convexTest(schema as any, modules);
+
+    // Create user and listing
+    const userId = await createTestUser(t, 'reporter@calpoly.edu');
+    const listingId = await createTestListing(t, 'seller-id');
+
+    // Simulate authenticated user
+    const asUser = t.withIdentity({
+      name: 'Reporter',
+      subject: 'reporter-subject',
+      email: 'reporter@calpoly.edu',
+    });
+
+    // Create report
+    const reportId = await asUser.mutation(api.reports.createReport, {
+      targetId: listingId,
+      targetType: 'listing',
+      reason: 'scam',
+      notes: 'This looks like a scam',
+    });
+
+    // Verify report was created
+    const report = await t.run(async (ctx: any) => {
+      return await ctx.db.get(reportId);
+    });
+
+    expect(report).toMatchObject({
+      targetId: listingId,
+      targetType: 'listing',
+      reporterId: userId,
+      reason: 'scam',
+      notes: 'This looks like a scam',
+    });
+    expect(typeof report?.createdAt).toBe('number');
+  });
+
+  it('createReport succeeds with valid profile report', async () => {
+    const t = convexTest(schema as any, modules);
+
+    // Create users and profile
+    const reporterId = await createTestUser(t, 'reporter@calpoly.edu');
+    const profileId = await createTestProfile(t, 'profile-user-id');
+
+    const asUser = t.withIdentity({
+      name: 'Reporter',
+      subject: 'reporter-subject',
+      email: 'reporter@calpoly.edu',
+    });
+
+    // Create report
+    const reportId = await asUser.mutation(api.reports.createReport, {
+      targetId: profileId,
+      targetType: 'profile',
+      reason: 'inappropriate',
+    });
+
+    // Verify report was created
+    const report = await t.run(async (ctx: any) => {
+      return await ctx.db.get(reportId);
+    });
+
+    expect(report).toMatchObject({
+      targetId: profileId,
+      targetType: 'profile',
+      reporterId,
+      reason: 'inappropriate',
+    });
+  });
+
+  it('createReport fails when user is not authenticated', async () => {
+    const t = convexTest(schema as any, modules);
+
+    const listingId = await createTestListing(t, 'seller-id');
+
+    await expect(async () => {
+      await t.mutation(api.reports.createReport, {
+        targetId: listingId,
+        targetType: 'listing',
+        reason: 'scam',
+      });
+    }).rejects.toThrow('You must be logged in to report content');
+  });
+
+  it('createReport rejects duplicate reports from same user', async () => {
+    const t = convexTest(schema as any, modules);
+
+    await createTestUser(t, 'reporter@calpoly.edu');
+    const listingId = await createTestListing(t, 'seller-id');
+
+    const asUser = t.withIdentity({
+      name: 'Reporter',
+      subject: 'reporter-subject',
+      email: 'reporter@calpoly.edu',
+    });
+
+    // First report succeeds
+    await asUser.mutation(api.reports.createReport, {
+      targetId: listingId,
+      targetType: 'listing',
+      reason: 'scam',
+    });
+
+    // Second report from same user fails
+    await expect(async () => {
+      await asUser.mutation(api.reports.createReport, {
+        targetId: listingId,
+        targetType: 'listing',
+        reason: 'spam',
+      });
+    }).rejects.toThrow('You have already reported this content');
+  });
+
+  it('createReport enforces rate limiting (10 reports per day)', async () => {
+    const t = convexTest(schema as any, modules);
+
+    await createTestUser(t, 'reporter@calpoly.edu');
+
+    const asUser = t.withIdentity({
+      name: 'Reporter',
+      subject: 'reporter-subject',
+      email: 'reporter@calpoly.edu',
+    });
+
+    // Create 10 different listings and report them all
+    for (let i = 0; i < 10; i++) {
+      const listingId = await createTestListing(t, `seller-${i}`);
+      await asUser.mutation(api.reports.createReport, {
+        targetId: listingId,
+        targetType: 'listing',
+        reason: 'spam',
+      });
+    }
+
+    // 11th report should fail
+    const listingId = await createTestListing(t, 'seller-11');
+    await expect(async () => {
+      await asUser.mutation(api.reports.createReport, {
+        targetId: listingId,
+        targetType: 'listing',
+        reason: 'spam',
+      });
+    }).rejects.toThrow('Report limit reached. Please try again later.');
+  });
+
+  it('createReport rejects invalid listing targetId', async () => {
+    const t = convexTest(schema as any, modules);
+
+    await createTestUser(t, 'reporter@calpoly.edu');
+
+    const asUser = t.withIdentity({
+      name: 'Reporter',
+      subject: 'reporter-subject',
+      email: 'reporter@calpoly.edu',
+    });
+
+    await expect(async () => {
+      await asUser.mutation(api.reports.createReport, {
+        targetId: 'invalid_id_12345',
+        targetType: 'listing',
+        reason: 'scam',
+      });
+    }).rejects.toThrow('Listing not found');
+  });
+
+  it('createReport rejects invalid profile targetId', async () => {
+    const t = convexTest(schema as any, modules);
+
+    await createTestUser(t, 'reporter@calpoly.edu');
+
+    const asUser = t.withIdentity({
+      name: 'Reporter',
+      subject: 'reporter-subject',
+      email: 'reporter@calpoly.edu',
+    });
+
+    await expect(async () => {
+      await asUser.mutation(api.reports.createReport, {
+        targetId: 'invalid_id_12345',
+        targetType: 'profile',
+        reason: 'inappropriate',
+      });
+    }).rejects.toThrow('Profile not found');
+  });
+
+  it('createReport rejects notes exceeding character limit', async () => {
+    const t = convexTest(schema as any, modules);
+
+    await createTestUser(t, 'reporter@calpoly.edu');
+    const listingId = await createTestListing(t, 'seller-id');
+
+    const asUser = t.withIdentity({
+      name: 'Reporter',
+      subject: 'reporter-subject',
+      email: 'reporter@calpoly.edu',
+    });
+
+    const longNotes = 'a'.repeat(501); // Exceeds 500 char limit
+
+    await expect(async () => {
+      await asUser.mutation(api.reports.createReport, {
+        targetId: listingId,
+        targetType: 'listing',
+        reason: 'scam',
+        notes: longNotes,
+      });
+    }).rejects.toThrow('Notes must be 500 characters or less');
+  });
+
+  it('createReport accepts notes within character limit', async () => {
+    const t = convexTest(schema as any, modules);
+
+    await createTestUser(t, 'reporter@calpoly.edu');
+    const listingId = await createTestListing(t, 'seller-id');
+
+    const asUser = t.withIdentity({
+      name: 'Reporter',
+      subject: 'reporter-subject',
+      email: 'reporter@calpoly.edu',
+    });
+
+    const validNotes = 'a'.repeat(500); // Exactly 500 chars
+
+    const reportId = await asUser.mutation(api.reports.createReport, {
+      targetId: listingId,
+      targetType: 'listing',
+      reason: 'scam',
+      notes: validNotes,
+    });
+
+    const report = await t.run(async (ctx: any) => {
+      return await ctx.db.get(reportId);
+    });
+
+    expect(report?.notes).toBe(validNotes);
+  });
+});

--- a/backend/convex/__tests__/schema.test.ts
+++ b/backend/convex/__tests__/schema.test.ts
@@ -21,6 +21,9 @@ describe('Convex schema', () => {
       'condition',
       'category',
       'status',
+      'isHidden',
+      'hiddenAt',
+      'hiddenReason',
       'createdAt',
       'postedOn',
     ]);

--- a/backend/convex/_generated/api.d.ts
+++ b/backend/convex/_generated/api.d.ts
@@ -13,6 +13,7 @@ import type * as auth from "../auth.js";
 import type * as http from "../http.js";
 import type * as listings from "../listings.js";
 import type * as profiles from "../profiles.js";
+import type * as reports from "../reports.js";
 import type * as users from "../users.js";
 
 import type {
@@ -27,6 +28,7 @@ declare const fullApi: ApiFromModules<{
   http: typeof http;
   listings: typeof listings;
   profiles: typeof profiles;
+  reports: typeof reports;
   users: typeof users;
 }>;
 

--- a/backend/convex/listings.ts
+++ b/backend/convex/listings.ts
@@ -61,16 +61,29 @@ export const getListings = query({
       .query('listings')
       .withIndex('by_status', (q) => q.eq('status', 'active'))
       .order('desc')
+      .filter((q) => q.neq(q.field('isHidden'), true))
       .collect();
     return listings;
   },
 });
 
 // Get a single listing by ID
+// Owners can see their own hidden listings, others cannot
 export const getListing = query({
   args: { id: v.id('listings') },
   handler: async (ctx, args) => {
-    return await ctx.db.get(args.id);
+    const listing = await ctx.db.get(args.id);
+    if (!listing) return null;
+
+    // If listing is hidden, only allow owner to see it
+    if (listing.isHidden) {
+      const identity = await ctx.auth.getUserIdentity();
+      if (!identity || identity.subject !== listing.sellerId) {
+        return null; // Hidden from non-owners
+      }
+    }
+
+    return listing;
   },
 });
 
@@ -148,6 +161,9 @@ export const searchAndFilterListings = query({
     if (filters.maxPrice !== undefined) {
       results = results.filter((l) => l.price <= filters.maxPrice!);
     }
+
+    // Filter out hidden content
+    results = results.filter((l) => l.isHidden !== true);
 
     // Apply sorting
     const sortBy = filters.sortBy ?? 'newest';
@@ -301,10 +317,31 @@ export const deleteListing = mutation({
 export const searchListings = query({
   args: { searchTerm: v.string() },
   handler: async (ctx, args) => {
-    return await ctx.db
+    const results = await ctx.db
       .query('listings')
       .withSearchIndex('search_listings', (q) =>
         q.search('title', args.searchTerm).eq('status', 'active')
+      )
+      .collect();
+
+    // Filter out hidden content
+    return results.filter((l) => l.isHidden !== true);
+  },
+});
+
+// Get user's own hidden listings (for owner awareness)
+export const getMyHiddenListings = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error('You must be logged in to view your hidden listings');
+    }
+
+    return await ctx.db
+      .query('listings')
+      .filter((q) =>
+        q.and(q.eq(q.field('sellerId'), identity.subject), q.eq(q.field('isHidden'), true))
       )
       .collect();
   },

--- a/backend/convex/reports.ts
+++ b/backend/convex/reports.ts
@@ -1,0 +1,92 @@
+import { v, ConvexError } from 'convex/values';
+import { mutation } from './_generated/server';
+import type { Id } from './_generated/dataModel';
+
+const MAX_NOTES_LENGTH = 500;
+const MAX_REPORTS_PER_DAY = 10;
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Create a new report for a listing or profile
+ * Includes validation, duplicate prevention, and rate limiting
+ */
+export const createReport = mutation({
+  args: {
+    targetId: v.string(),
+    targetType: v.union(v.literal('listing'), v.literal('profile')),
+    reason: v.union(v.literal('scam'), v.literal('inappropriate'), v.literal('spam')),
+    notes: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    // 1. Validate user is authenticated
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new ConvexError('You must be logged in to report content');
+    }
+
+    // 2. Get the user from the users table
+    const user = await ctx.db
+      .query('users')
+      .withIndex('by_email', (q) => q.eq('email', identity.email!))
+      .first();
+
+    if (!user) {
+      throw new ConvexError('User not found');
+    }
+
+    // 3. Validate notes length if provided
+    if (args.notes && args.notes.length > MAX_NOTES_LENGTH) {
+      throw new ConvexError(`Notes must be ${MAX_NOTES_LENGTH} characters or less`);
+    }
+
+    // 4. Validate target exists
+    if (args.targetType === 'listing') {
+      const listing = await ctx.db.get(args.targetId as Id<'listings'>);
+      if (!listing) {
+        throw new ConvexError('Listing not found');
+      }
+    } else if (args.targetType === 'profile') {
+      const profile = await ctx.db.get(args.targetId as Id<'profiles'>);
+      if (!profile) {
+        throw new ConvexError('Profile not found');
+      }
+    }
+
+    // 5. Check for duplicate report (same user + same target)
+    const existingReport = await ctx.db
+      .query('reports')
+      .withIndex('by_target', (q) =>
+        q.eq('targetId', args.targetId).eq('targetType', args.targetType)
+      )
+      .filter((q) => q.eq(q.field('reporterId'), user._id))
+      .first();
+
+    if (existingReport) {
+      throw new ConvexError('You have already reported this content');
+    }
+
+    // 6. Check rate limiting (max 10 reports per day)
+    const oneDayAgo = Date.now() - ONE_DAY_MS;
+    const recentReports = await ctx.db
+      .query('reports')
+      .withIndex('by_reporter', (q) => q.eq('reporterId', user._id))
+      .filter((q) => q.gt(q.field('createdAt'), oneDayAgo))
+      .collect();
+
+    if (recentReports.length >= MAX_REPORTS_PER_DAY) {
+      throw new ConvexError('Report limit reached. Please try again later.');
+    }
+
+    // 7. Create the report
+    const reportId = await ctx.db.insert('reports', {
+      targetId: args.targetId,
+      targetType: args.targetType,
+      reporterId: user._id,
+      reason: args.reason,
+      notes: args.notes,
+      createdAt: Date.now(),
+    });
+
+    return reportId;
+  },
+});

--- a/backend/convex/reports.ts
+++ b/backend/convex/reports.ts
@@ -4,6 +4,7 @@ import type { Id } from './_generated/dataModel';
 
 const MAX_NOTES_LENGTH = 500;
 const MAX_REPORTS_PER_DAY = 10;
+const REPORT_THRESHOLD = 3; // Number of unique reporters before auto-hide
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 /**
@@ -24,35 +25,50 @@ export const createReport = mutation({
       throw new ConvexError('You must be logged in to report content');
     }
 
-    // 2. Get the user from the users table
+    // 2. Validate and normalize email
+    if (!identity.email) {
+      throw new ConvexError('User email missing');
+    }
+    const email = identity.email.toLowerCase().trim();
+
+    // 3. Get the user from the users table
     const user = await ctx.db
       .query('users')
-      .withIndex('by_email', (q) => q.eq('email', identity.email!))
+      .withIndex('by_email', (q) => q.eq('email', email))
       .first();
 
     if (!user) {
       throw new ConvexError('User not found');
     }
 
-    // 3. Validate notes length if provided
+    // 4. Validate notes length if provided
     if (args.notes && args.notes.length > MAX_NOTES_LENGTH) {
       throw new ConvexError(`Notes must be ${MAX_NOTES_LENGTH} characters or less`);
     }
 
-    // 4. Validate target exists
-    if (args.targetType === 'listing') {
-      const listing = await ctx.db.get(args.targetId as Id<'listings'>);
-      if (!listing) {
-        throw new ConvexError('Listing not found');
+    // 5. Validate target exists and handle malformed IDs
+    try {
+      if (args.targetType === 'listing') {
+        const listing = await ctx.db.get(args.targetId as Id<'listings'>);
+        if (!listing) {
+          throw new ConvexError('Listing not found');
+        }
+      } else if (args.targetType === 'profile') {
+        const profile = await ctx.db.get(args.targetId as Id<'profiles'>);
+        if (!profile) {
+          throw new ConvexError('Profile not found');
+        }
       }
-    } else if (args.targetType === 'profile') {
-      const profile = await ctx.db.get(args.targetId as Id<'profiles'>);
-      if (!profile) {
+    } catch {
+      // Handle malformed IDs by throwing user-friendly errors
+      if (args.targetType === 'listing') {
+        throw new ConvexError('Listing not found');
+      } else {
         throw new ConvexError('Profile not found');
       }
     }
 
-    // 5. Check for duplicate report (same user + same target)
+    // 6. Check for duplicate report (same user + same target)
     const existingReport = await ctx.db
       .query('reports')
       .withIndex('by_target', (q) =>
@@ -86,6 +102,35 @@ export const createReport = mutation({
       notes: args.notes,
       createdAt: Date.now(),
     });
+
+    // 8. Check if content should be auto-hidden
+    // Count all reports for this target
+    const allReports = await ctx.db
+      .query('reports')
+      .withIndex('by_target', (q) =>
+        q.eq('targetId', args.targetId).eq('targetType', args.targetType)
+      )
+      .collect();
+
+    // Count unique reporters using Set
+    const uniqueReporters = new Set(allReports.map((r) => r.reporterId)).size;
+
+    // If threshold reached, hide the content
+    if (uniqueReporters >= REPORT_THRESHOLD) {
+      if (args.targetType === 'listing') {
+        await ctx.db.patch(args.targetId as Id<'listings'>, {
+          isHidden: true,
+          hiddenAt: Date.now(),
+          hiddenReason: 'auto_moderation',
+        });
+      } else if (args.targetType === 'profile') {
+        await ctx.db.patch(args.targetId as Id<'profiles'>, {
+          isHidden: true,
+          hiddenAt: Date.now(),
+          hiddenReason: 'auto_moderation',
+        });
+      }
+    }
 
     return reportId;
   },

--- a/backend/convex/schema.ts
+++ b/backend/convex/schema.ts
@@ -23,6 +23,9 @@ export default defineSchema({
       v.literal('inactive'),
       v.literal('deleted')
     ),
+    isHidden: v.optional(v.boolean()),
+    hiddenAt: v.optional(v.number()),
+    hiddenReason: v.optional(v.string()),
     createdAt: v.number(),
     postedOn: v.number(),
   })
@@ -46,6 +49,9 @@ export default defineSchema({
     year: v.number(),
     rating: v.number(),
     review_count: v.number(),
+    isHidden: v.optional(v.boolean()),
+    hiddenAt: v.optional(v.number()),
+    hiddenReason: v.optional(v.string()),
   })
     .index('by_name', ['name'])
     .index('by_userId', ['userId']),

--- a/backend/convex/schema.ts
+++ b/backend/convex/schema.ts
@@ -54,4 +54,15 @@ export default defineSchema({
     name: v.union(v.string(), v.null()),
     createdAt: v.number(),
   }).index('by_email', ['email']),
+
+  reports: defineTable({
+    targetId: v.string(), // Can be listing or profile ID
+    targetType: v.union(v.literal('listing'), v.literal('profile')),
+    reporterId: v.id('users'),
+    reason: v.union(v.literal('scam'), v.literal('inappropriate'), v.literal('spam')),
+    notes: v.optional(v.string()),
+    createdAt: v.number(),
+  })
+    .index('by_target', ['targetId', 'targetType'])
+    .index('by_reporter', ['reporterId']),
 });


### PR DESCRIPTION
# [POLY-19] Create report schema and submission endpoint

## Linear Issue
Linear: [POLY-19](https://linear.app/poly-buys/issue/POLY-19/create-report-schema-and-submission-endpoint)

## Summary
Implements the foundational data layer for the reporting system. Users can now report inappropriate listings and profiles with proper validation, duplicate prevention, and rate limiting.

## Changes Made

### Schema
- **Added `reports` table** to [backend/convex/schema.ts](file:///Users/coleh/PolyBuys/backend/convex/schema.ts)
  - Fields: `targetId`, `targetType`, `reporterId`, `reason`, `notes`, `createdAt`
  - Indexes: `by_target` (for querying reports by target), `by_reporter` (for rate limiting)

### Backend
- **Created [backend/convex/reports.ts](file:///Users/coleh/PolyBuys/backend/convex/reports.ts)** with `createReport` mutation
  - ✅ Authentication required (validates user via `ctx.auth.getUserIdentity()`)
  - ✅ Input validation (target exists, notes max 500 chars)
  - ✅ Duplicate prevention (same user cannot report same target twice)
  - ✅ Rate limiting (max 10 reports per 24 hours per user)
  - ✅ Security (reporterId automatically set, never exposed)

### Tests
- **Created [backend/convex/__tests__/reports.test.ts](file:///Users/coleh/PolyBuys/backend/convex/__tests__/reports.test.ts)** with comprehensive coverage
  - 9 test cases covering all acceptance criteria
  - Tests for valid creation, duplicates, rate limiting, invalid targets, authentication, and character limits
  - **All tests passing ✅**

## Testing Steps

### Run Tests
```bash
npm test -- backend/convex/__tests__/reports.test.ts
```

Expected: All 9 tests pass

### Manual Testing (if desired)
1. Deploy to dev environment: `npx convex dev` in `backend/`
2. Authenticate as a user
3. Create a report:
   ```javascript
   await ctx.mutation(api.reports.createReport, {
     targetId: "<valid-listing-id>",
     targetType: "listing",
     reason: "scam",
     notes: "Test report"
   });
   ```
4. Verify duplicate prevention by trying to report the same target again
5. Verify rate limiting by creating 11 reports within 24 hours

## Acceptance Criteria

All criteria from POLY-19 have been met:

- ✅ Reports table exists in schema with proper indexes
- ✅ createReport mutation validates inputs
- ✅ Duplicate reports from same user are rejected
- ✅ Rate limiting enforced (10/day)
- ✅ Reporter ID never exposed in queries
- ✅ Unit tests passing (9/9)

## What's NOT Included

As specified in the Linear issue:
- ❌ Auto-hide logic (separate sub-issue)
- ❌ Query endpoints to view reports (admin feature, future)
- ❌ Notifications to reported users
- ❌ Admin dashboard or moderation UI

## Notes

- Used `v.string()` for `targetId` since Convex doesn't support union types for IDs. Runtime validation ensures the target exists.
- Follows existing patterns from [listings.ts](file:///Users/coleh/PolyBuys/backend/convex/listings.ts) and [otpAuth.ts](file:///Users/coleh/PolyBuys/backend/convex/otpAuth.ts) for consistency
- All error messages are user-friendly and don't expose internal details

## Screenshots/Recordings

N/A - Backend only, no UI changes

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can report listings and profiles (reasons: scam, inappropriate, spam) with optional notes (≤500 chars).
  * Content is auto-hidden after 3 unique reports; owners can still view their own hidden items.
  * New view for users to see their own hidden listings; hidden items are excluded from public listings and search.

* **Abuse Protections**
  * Duplicate-report prevention and a daily rate limit (10 reports/user/day).

* **Tests**
  * Comprehensive test suite covering reporting flows, limits, validation, hiding, and visibility rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->