### PR TITLE
[POLY-25] Add tags field to listing schema with validation

### DIFF
--- a/backend/convex/__tests__/listings.test.ts
+++ b/backend/convex/__tests__/listings.test.ts
@@ -28,6 +28,7 @@ describe('Listings mutations', () => {
     category: 'textbooks' as const,
     images: ['https://example.com/book1.png'],
     condition: 'used' as const,
+    tags: ['csc202'],
   };
 
   it('createListing succeeds with valid data', async () => {
@@ -51,6 +52,7 @@ describe('Listings mutations', () => {
       category: baseArgs.category,
       status: 'active',
       sellerId: 'alice-id',
+      tags: baseArgs.tags,
     });
 
     // Extra checks: images + postedOn/createdAt exist
@@ -95,6 +97,95 @@ describe('Listings mutations', () => {
         images: tooManyImages,
       });
     }).rejects.toThrowError('Must have 1-8 images');
+  });
+
+  it('createListing normalizes tags to be trimmed and in lowercase', async () => {
+    const t = convexTest(schema as any, modules);
+    const asUser = t.withIdentity({ name: 'Alice' });
+
+    const unnormalized = '   fOUrTH EditION ';
+
+    const listingId = await asUser.mutation(api.listings.createListing, {
+      ...baseArgs,
+      tags: [unnormalized],
+    });
+
+    const listing = await t.run(async (ctx) => {
+      return await ctx.db.get(listingId);
+    });
+
+    expect(listing).toBeDefined();
+    expect(listing?.tags).toEqual(['fourth edition']);
+  });
+
+  it('createListing removes duplicate tags', async () => {
+    const t = convexTest(schema as any, modules);
+    const asUser = t.withIdentity({ name: 'Alice' });
+
+    const listingId = await asUser.mutation(api.listings.createListing, {
+      ...baseArgs,
+      tags: ['fourth edition', 'FOURTH EDITION', '   fourth edition    ', 'csc101'],
+    });
+
+    const listing = await t.run(async (ctx) => {
+      return await ctx.db.get(listingId);
+    });
+
+    expect(listing).toBeDefined();
+    expect(listing?.tags).toEqual(['fourth edition', 'csc101']);
+  });
+
+  it('createListing fails when tags array is too long', async () => {
+    const t = convexTest(schema as any, modules);
+    const asUser = t.withIdentity({ name: 'Alice' });
+
+    await expect(async () => {
+      await asUser.mutation(api.listings.createListing, {
+        ...baseArgs,
+        tags: ['csc101', 'gently used', 'fourth edition', 'answers', 'textbook', 'hardcover'],
+      });
+    }).rejects.toThrowError('Maximum 5 tags allowed');
+  });
+
+  it('createListing fails when tag is empty', async () => {
+    const t = convexTest(schema as any, modules);
+    const asUser = t.withIdentity({ name: 'Alice' });
+
+    await expect(async () => {
+      await asUser.mutation(api.listings.createListing, {
+        ...baseArgs,
+        tags: [' '],
+      });
+    }).rejects.toThrowError('Empty tags are not allowed');
+  });
+
+  it('createListing fails when tag is >20 characters long', async () => {
+    const t = convexTest(schema as any, modules);
+    const asUser = t.withIdentity({ name: 'Alice' });
+
+    await expect(async () => {
+      await asUser.mutation(api.listings.createListing, {
+        ...baseArgs,
+        tags: ['supercalifragilisticexpialidocious'],
+      });
+    }).rejects.toThrowError('Tags must be 20 characters or less');
+  });
+
+  it('createListing succeeds with no tags', async () => {
+    const t = convexTest(schema as any, modules);
+    const asUser = t.withIdentity({ name: 'Alice' });
+
+    const listingId = await asUser.mutation(api.listings.createListing, {
+      ...baseArgs,
+      tags: [],
+    });
+
+    const listing = await t.run(async (ctx) => {
+      return await ctx.db.get(listingId);
+    });
+
+    expect(listing).toBeDefined();
+    expect(listing?.tags).toEqual([]);
   });
 
   it('updateListing allows the owner to update fields', async () => {
@@ -167,5 +258,98 @@ describe('Listings mutations', () => {
         title: 'New title after delete',
       });
     }).rejects.toThrowError('Cannot update a deleted listing');
+  });
+
+  it('updateListing, normalizes tags to be trimmed and in lowercase', async () => {
+    const t = convexTest(schema as any, modules);
+    const asOwner = t.withIdentity({ name: 'Owner', subject: 'owner-id' });
+
+    const unnormalized = '   fOUrTH EditION ';
+
+    const listingId = await asOwner.mutation(api.listings.createListing, {
+      ...baseArgs,
+      tags: [unnormalized],
+    });
+
+    await asOwner.mutation(api.listings.updateListing, {
+      id: listingId,
+      tags: ['   fOurTH EdiTIOn  '],
+    });
+
+    const updated = await t.run(async (ctx) => {
+      return await ctx.db.get(listingId);
+    });
+    expect(updated).toBeDefined();
+    expect(updated?.tags).toEqual(['fourth edition']);
+  });
+
+  it('updateListing removes duplicate tags', async () => {
+    const t = convexTest(schema as any, modules);
+    const asOwner = t.withIdentity({ name: 'Owner', subject: 'owner-id' });
+
+    const listingId = await asOwner.mutation(api.listings.createListing, {
+      ...baseArgs,
+      tags: ['fourth edition', 'FOURTH EDITION', '   fourth edition    ', 'csc101'],
+    });
+
+    const listing = await t.run(async (ctx) => {
+      return await ctx.db.get(listingId);
+    });
+
+    expect(listing).toBeDefined();
+    expect(listing?.tags).toEqual(['fourth edition', 'csc101']);
+  });
+
+  it('updateListing fails when tags array is too long', async () => {
+    const t = convexTest(schema as any, modules);
+    const asOwner = t.withIdentity({ name: 'Owner', subject: 'owner-id' });
+
+    await expect(async () => {
+      await asOwner.mutation(api.listings.createListing, {
+        ...baseArgs,
+        tags: ['csc101', 'gently used', 'fourth edition', 'answers', 'textbook', 'hardcover'],
+      });
+    }).rejects.toThrowError('Maximum 5 tags allowed');
+  });
+
+  it('updateListing fails when tag is empty', async () => {
+    const t = convexTest(schema as any, modules);
+    const asOwner = t.withIdentity({ name: 'Owner', subject: 'owner-id' });
+
+    await expect(async () => {
+      await asOwner.mutation(api.listings.createListing, {
+        ...baseArgs,
+        tags: [' '],
+      });
+    }).rejects.toThrowError('Empty tags are not allowed');
+  });
+
+  it('updateListing fails when tag is >20 characters long', async () => {
+    const t = convexTest(schema as any, modules);
+    const asOwner = t.withIdentity({ name: 'Owner', subject: 'owner-id' });
+
+    await expect(async () => {
+      await asOwner.mutation(api.listings.createListing, {
+        ...baseArgs,
+        tags: ['supercalifragilisticexpialidocious'],
+      });
+    }).rejects.toThrowError('Tags must be 20 characters or less');
+  });
+
+  it('updateListing succeeds with no tags', async () => {
+    const t = convexTest(schema as any, modules);
+    const asOwner = t.withIdentity({ name: 'Owner', subject: 'owner-id' });
+
+    const listingId = await asOwner.mutation(api.listings.createListing, {
+      ...baseArgs,
+      tags: [],
+    });
+
+    const listing = await t.run(async (ctx) => {
+      return await ctx.db.get(listingId);
+    });
+
+    expect(listing).toBeDefined();
+    expect(listing?.tags).toEqual([]);
   });
 });

--- a/backend/convex/__tests__/listings.test.ts
+++ b/backend/convex/__tests__/listings.test.ts
@@ -287,8 +287,9 @@ describe('Listings mutations', () => {
     const t = convexTest(schema as any, modules);
     const asOwner = t.withIdentity({ name: 'Owner', subject: 'owner-id' });
 
-    const listingId = await asOwner.mutation(api.listings.createListing, {
-      ...baseArgs,
+    const listingId = await asOwner.mutation(api.listings.createListing, baseArgs);
+    await asOwner.mutation(api.listings.updateListing, {
+      id: listingId,
       tags: ['fourth edition', 'FOURTH EDITION', '   fourth edition    ', 'csc101'],
     });
 
@@ -304,9 +305,11 @@ describe('Listings mutations', () => {
     const t = convexTest(schema as any, modules);
     const asOwner = t.withIdentity({ name: 'Owner', subject: 'owner-id' });
 
+    const listingId = await asOwner.mutation(api.listings.createListing, baseArgs);
+
     await expect(async () => {
-      await asOwner.mutation(api.listings.createListing, {
-        ...baseArgs,
+      await asOwner.mutation(api.listings.updateListing, {
+        id: listingId,
         tags: ['csc101', 'gently used', 'fourth edition', 'answers', 'textbook', 'hardcover'],
       });
     }).rejects.toThrowError('Maximum 5 tags allowed');
@@ -316,9 +319,11 @@ describe('Listings mutations', () => {
     const t = convexTest(schema as any, modules);
     const asOwner = t.withIdentity({ name: 'Owner', subject: 'owner-id' });
 
+    const listingId = await asOwner.mutation(api.listings.createListing, baseArgs);
+
     await expect(async () => {
-      await asOwner.mutation(api.listings.createListing, {
-        ...baseArgs,
+      await asOwner.mutation(api.listings.updateListing, {
+        id: listingId,
         tags: [' '],
       });
     }).rejects.toThrowError('Empty tags are not allowed');
@@ -340,8 +345,9 @@ describe('Listings mutations', () => {
     const t = convexTest(schema as any, modules);
     const asOwner = t.withIdentity({ name: 'Owner', subject: 'owner-id' });
 
-    const listingId = await asOwner.mutation(api.listings.createListing, {
-      ...baseArgs,
+    const listingId = await asOwner.mutation(api.listings.createListing, baseArgs);
+    await asOwner.mutation(api.listings.updateListing, {
+      id: listingId,
       tags: [],
     });
 

--- a/backend/convex/__tests__/schema.test.ts
+++ b/backend/convex/__tests__/schema.test.ts
@@ -23,6 +23,7 @@ describe('Convex schema', () => {
       'status',
       'createdAt',
       'postedOn',
+      'tags',
     ]);
   });
 

--- a/backend/convex/listings.ts
+++ b/backend/convex/listings.ts
@@ -10,6 +10,12 @@ export type Listing = Doc<'listings'> & {
   status: ListingStatus;
 };
 
+export const TAG_CONSTRAINTS = {
+  MAX_TAGS: 5,
+  MAX_TAG_LENGTH: 20,
+  MIN_TAG_LENGTH: 1,
+};
+
 async function verifyOwnership(
   ctx: MutationCtx,
   listingId: Id<'listings'>
@@ -65,6 +71,17 @@ export const getListings = query({
     return listings;
   },
 });
+
+// Normalize tages to lowercase and within 1-20 characters exclusive
+function normalizeTags(tags: string[]): string[] {
+  return [
+    ...new Set(
+      tags
+        .map((tag) => tag.trim().toLowerCase())
+        .filter((tag) => tag.length >= 1 && tag.length <= 20)
+    ),
+  ].slice(0, 5);
+}
 
 // Get a single listing by ID
 export const getListing = query({
@@ -197,12 +214,31 @@ export const createListing = mutation({
     category: categoryValidator,
     images: v.array(v.string()),
     condition: conditionValidator,
+    tags: v.optional(v.array(v.string())),
   },
   handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) {
       throw new Error('You must be logged in to create a listing');
     }
+
+    if (args.tags) {
+      if (args.tags.length > TAG_CONSTRAINTS.MAX_TAGS) {
+        throw new Error(`Maximum ${TAG_CONSTRAINTS.MAX_TAGS} tags allowed`);
+      }
+
+      for (const tag of args.tags) {
+        const trimmed = tag.trim();
+        if (!trimmed) {
+          throw new Error('Empty tags are not allowed');
+        }
+        if (trimmed.length > TAG_CONSTRAINTS.MAX_TAG_LENGTH) {
+          throw new Error(`Tags must be ${TAG_CONSTRAINTS.MAX_TAG_LENGTH} characters or less`);
+        }
+      }
+    }
+    // Normalize before saving
+    const normalizedTags = normalizeTags(args.tags ?? []);
     validateTitle(args.title);
     validateImages(args.images);
     const now = Date.now();
@@ -212,6 +248,7 @@ export const createListing = mutation({
       status: 'active',
       createdAt: now,
       postedOn: now,
+      tags: normalizedTags,
     });
     return listingId;
   },
@@ -226,6 +263,7 @@ export const updateListing = mutation({
     images: v.optional(v.array(v.string())),
     condition: v.optional(conditionValidator),
     category: v.optional(categoryValidator),
+    tags: v.optional(v.array(v.string())),
   },
   handler: async (ctx, args) => {
     const listing = await verifyOwnership(ctx, args.id);
@@ -233,6 +271,24 @@ export const updateListing = mutation({
     if (listing.status === 'deleted') {
       throw new Error('Cannot update a deleted listing');
     }
+
+    if (args.tags) {
+      if (args.tags.length > TAG_CONSTRAINTS.MAX_TAGS) {
+        throw new Error(`Maximum ${TAG_CONSTRAINTS.MAX_TAGS} tags allowed`);
+      }
+
+      for (const tag of args.tags) {
+        const trimmed = tag.trim();
+        if (!trimmed) {
+          throw new Error('Empty tags are not allowed');
+        }
+        if (trimmed.length > TAG_CONSTRAINTS.MAX_TAG_LENGTH) {
+          throw new Error(`Tags must be ${TAG_CONSTRAINTS.MAX_TAG_LENGTH} characters or less`);
+        }
+      }
+    }
+    // Normalize before saving
+    const normalizedTags = normalizeTags(args.tags ?? []);
 
     const update: Partial<Doc<'listings'>> = {};
 
@@ -262,6 +318,9 @@ export const updateListing = mutation({
     }
     if (args.description !== undefined) {
       update.description = args.description;
+    }
+    if (args.tags !== undefined) {
+      update.tags = normalizedTags;
     }
 
     if (Object.keys(update).length === 0) {

--- a/backend/convex/schema.ts
+++ b/backend/convex/schema.ts
@@ -25,11 +25,13 @@ export default defineSchema({
     ),
     createdAt: v.number(),
     postedOn: v.number(),
+    tags: v.optional(v.array(v.string())),
   })
     .index('by_status', ['status'])
     .index('by_category', ['category'])
     .index('by_status_category', ['status', 'category'])
     .index('by_status_createdAt', ['status', 'createdAt'])
+    .index('by_tag', ['tags'])
     .searchIndex('search_listings', {
       searchField: 'title',
       filterFields: ['status', 'category', 'condition', 'description'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -188,6 +188,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2031,6 +2032,7 @@
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.6.tgz",
       "integrity": "sha512-GaTI4nXDrs7l0qaJ6Rg06dtOXTBCG6TMDB44zbqofCIC4PqC7SEvmFFtpxzCDw9W5aJ7RKVshgXTLvLdBFV/qw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
         "@babel/helper-compilation-targets": "^7.28.6",
@@ -5201,7 +5203,6 @@
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
       "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -5724,6 +5725,7 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.28.tgz",
       "integrity": "sha512-d1QDn+KNHfHGt3UIwOZvupvdsDdiHYZBEj7+wL2yDVo3tMezamYy60H9s3EnNVE1Ae1ty0trc7F2OKqo/RmsdQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.14.0",
         "escape-string-regexp": "^4.0.0",
@@ -5939,6 +5941,7 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -6000,6 +6003,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -6281,6 +6285,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6697,6 +6702,7 @@
       "integrity": "sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/transform": "30.2.0",
         "@types/babel__core": "^7.20.5",
@@ -7044,6 +7050,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7784,6 +7791,7 @@
       "resolved": "https://registry.npmjs.org/convex/-/convex-1.31.6.tgz",
       "integrity": "sha512-9cIsOzepa3s9DURRF+fZHxbNuzLgilg9XGQCc45v0Xx4FemqeIezpPFSJF9WHC9ckk43TDUUXLecvLVt9djPkw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "esbuild": "0.27.0",
         "prettier": "^3.0.0"
@@ -8794,6 +8802,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9409,6 +9418,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-52.0.48.tgz",
       "integrity": "sha512-/HR/vuo57KGEWlvF3GWaquwEAjXuA5hrOCsaLcZ3pMSA8mQ27qKd1jva4GWzpxXYedlzs/7LLP1XpZo6hXTsog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "0.22.27",
@@ -9475,6 +9485,7 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-17.0.8.tgz",
       "integrity": "sha512-XfWRyQAf1yUNgWZ1TnE8pFBMqGmFP5Gb+SFSgszxDdOoheB/NI5D4p7q86kI2fvGyfTrxAe+D+74nZkfsGvUlg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/config": "~10.0.11",
         "@expo/env": "~0.4.2"
@@ -9525,6 +9536,7 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-7.0.5.tgz",
       "integrity": "sha512-3KptlJtcYDPWohk0MfJU75MJFh2ybavbtcSd84zEPfw9s1q3hjimw3sXnH03ZxP54kiEWldvKmmnGcVffBDB1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "expo-constants": "~17.0.5",
         "invariant": "^2.2.4"
@@ -16827,7 +16839,6 @@
       "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
       "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "preact": ">=10"
       }
@@ -17105,6 +17116,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -17148,6 +17160,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -17202,6 +17215,7 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.76.9.tgz",
       "integrity": "sha512-+LRwecWmTDco7OweGsrECIqJu0iyrREd6CTCgC/uLLYipiHvk+MH9nd6drFtCw/6Blz6eoKTcH9YTTJusNtrWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.6.3",
         "@react-native/assets-registry": "0.76.9",
@@ -17287,6 +17301,7 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.12.0.tgz",
       "integrity": "sha512-ukk5PxcF4p3yu6qMZcmeiZgowhb5AsKRnil54YFUUAXVIS7PJcMHGGC+q44fCiBg44/1AJk5njGMez1m9H0BVQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -17297,6 +17312,7 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.4.0.tgz",
       "integrity": "sha512-c7zc7Zwjty6/pGyuuvh9gK3YBYqHPOxrhXfG1lF4gHlojQSmIx2piNbNaV+Uykj+RDTmFXK0e/hA+fucw/Qozg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
@@ -18170,6 +18186,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19743,6 +19760,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/packages/shared/types/listing.ts
+++ b/packages/shared/types/listing.ts
@@ -18,6 +18,7 @@ export interface Listing {
   status: ListingStatus;
   createdAt: number;
   postedOn: number;
+  tags?: string[];
 }
 
 export interface CreateListingInput {
@@ -28,4 +29,5 @@ export interface CreateListingInput {
   category: ListingCategory;
   condition: ListingCondition;
   images: string[];
+  tags?: string[];
 }


### PR DESCRIPTION
## Linked Issues

Linear: [POLY-25](https://linear.app/poly-buys/issue/POLY-25/add-tags-field-to-listing-schema-with-validation)

## Summary

- Added tags field to listing schema
- Added validation functions for tags field
- Tested the tags field is used correctly by creating test cases in listings.test.ts

## How to Test

Steps to verify locally:

- Run `npm test` to make sure that all test cases pass, especially test cases from listings.test.ts

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Lint/tests pass locally (`npm run lint`)
- [ ] Docs updated (README/ADR/changelog if needed)
- [ ] Follows conventional commit format
- [ ] No merge conflicts with `dev`

## Screenshots / Demos

(if UI or visible behavior - attach images, videos, or GIFs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Listings now support optional tags for organization and discovery.
  * Tags are normalized (trimmed, lowercased) and deduplicated on submit.
  * Tags are limited to 5 per listing, max 20 characters each, and empty tags are rejected.
  * Tags are indexed to enable tag-based lookups.

* **Tests**
  * Added comprehensive tests covering normalization, deduplication, validation, persistence, and retrieval of tags.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->