### PR TITLE
add docs for s3 convex config

### DIFF
--- a/docs/SELF_HOSTED_CONVEX.md
+++ b/docs/SELF_HOSTED_CONVEX.md
@@ -25,6 +25,7 @@ PolyBuys uses **self-hosted Convex** deployed on Railway instead of Convex cloud
 - **Backend URL**: `https://api.polybuys.com`
 - **Actions URL**: `https://actions.polybuys.com`
 - **Database**: SQLite (default) or PostgreSQL/MySQL (configurable)
+- **Object Storage**: Container filesystem (default) or S3-compatible storage
 
 ## Developer Setup
 
@@ -134,6 +135,31 @@ The Convex backend runs in a Docker container on Railway:
    - `api.polybuys.com` → port 3210
    - `actions.polybuys.com` → port 3211
 
+### S3 Storage on Railway
+
+By default, the Convex backend stores file data on the container filesystem. To
+use durable object storage (recommended for production), configure S3 buckets
+and set these environment variables on the **Convex Railway service**:
+
+```bash
+AWS_REGION=your-region
+AWS_ACCESS_KEY_ID=your-access-key-id
+AWS_SECRET_ACCESS_KEY=your-secret-access-key
+S3_STORAGE_EXPORTS_BUCKET=convex-snapshot-exports
+S3_STORAGE_SNAPSHOT_IMPORTS_BUCKET=convex-snapshot-imports
+S3_STORAGE_MODULES_BUCKET=convex-modules
+S3_STORAGE_FILES_BUCKET=convex-user-files
+S3_STORAGE_SEARCH_BUCKET=convex-search-indexes
+```
+
+Optional (required for R2 or other S3-compatible providers):
+
+```bash
+S3_ENDPOINT_URL=https://<your-s3-compatible-endpoint>
+```
+
+After setting variables in Railway, redeploy the Convex backend service.
+
 ### Frontend Deployment
 
 When deploying the Expo app (Netlify, Vercel, EAS, etc.):
@@ -181,6 +207,25 @@ npx convex export --path backup.zip
 # Export specific table
 npx convex export --table listings --path listings-backup.jsonl
 ```
+
+### Migrating Storage Providers
+
+If you switch between filesystem storage and S3 storage (or vice versa), move
+data with a full snapshot export/import:
+
+```bash
+# Export from current backend
+npx convex export --path backup.zip
+```
+
+Then point your CLI at a fresh backend using the new storage provider and run:
+
+```bash
+# Import into new backend (replaces all existing data)
+npx convex import --replace-all backup.zip
+```
+
+Run this during a maintenance window, since imports replace existing data.
 
 ### Monitoring
 
@@ -232,6 +277,6 @@ npx convex dev --verbose
 ### Future Considerations
 
 - **PostgreSQL/MySQL**: Can migrate from SQLite if needed
-- **S3 Storage**: Can configure for files and exports
+- **S3 Storage**: Use the "S3 Storage on Railway" section above
 - **Dashboard Deployment**: Optional, for team access
 - **Multiple Environments**: Can set up staging/production backends

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -248,6 +248,18 @@ We also include an **`.editorconfig`** file to normalize IDE settings across the
 - `CONVEX_SELF_HOSTED_ADMIN_KEY` - Admin key for self-hosted backend (get from tech leads)
 - `AUTH_RESEND_KEY` - Resend API key for sending verification emails (get from tech leads)
 
+**Convex Runtime (Railway service environment):**
+
+- `AWS_REGION` - AWS region for S3 buckets
+- `AWS_ACCESS_KEY_ID` - S3 access key ID for backend storage access
+- `AWS_SECRET_ACCESS_KEY` - S3 secret key for backend storage access
+- `S3_STORAGE_EXPORTS_BUCKET` - Bucket for Convex snapshot exports
+- `S3_STORAGE_SNAPSHOT_IMPORTS_BUCKET` - Bucket for Convex snapshot imports
+- `S3_STORAGE_MODULES_BUCKET` - Bucket for Convex module bundles
+- `S3_STORAGE_FILES_BUCKET` - Bucket for user-uploaded files
+- `S3_STORAGE_SEARCH_BUCKET` - Bucket for Convex search indexes
+- `S3_ENDPOINT_URL` - Optional endpoint for R2/S3-compatible providers
+
 Ask tech leads for any additional secrets needed (API keys, etc.)
 
 ### Documentation


### PR DESCRIPTION
## Linked Issues

Linear: POLY-40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive S3 storage configuration guide for self-hosted deployments, enabling S3-compatible storage as an alternative to container filesystem.
  * Introduced storage provider migration documentation with export and import procedures for transitioning between filesystem and S3 storage.
  * Documented required and optional environment variables for S3 storage setup on Railway.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->