### PR TITLE
feat: exclude hidden content from feed and handle hidden states

### DIFF
--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -112,7 +112,8 @@ export default function HomeScreen() {
     processedCursorsRef.current.clear();
   }, [filters.category, filters.minPrice, filters.maxPrice, selectedTags]);
 
-  const listings = allListings;
+  // Defensive client-side guard in case stale cache includes hidden listings.
+  const listings = allListings.filter((listing) => listing.isHidden !== true);
 
   const hasActiveFilters =
     !!filters.category ||

--- a/frontend/app/listings/[id].tsx
+++ b/frontend/app/listings/[id].tsx
@@ -3,6 +3,8 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useQuery } from 'convex/react';
 import { api } from 'convex/_generated/api';
 import { Id } from 'convex/_generated/dataModel';
+import ListingUnavailable from '../../components/ListingUnavailable';
+import HiddenBanner from '../../components/HiddenBanner';
 
 export default function ListingDetailScreen() {
   const { id } = useLocalSearchParams();
@@ -28,15 +30,21 @@ export default function ListingDetailScreen() {
   }
 
   if (listing === null) {
-    return (
-      <View style={styles.container}>
-        <Text>Listing not found</Text>
-      </View>
-    );
+    return <ListingUnavailable />;
+  }
+
+  const isOwner = currentUserSubject === listing.sellerId;
+  const isHidden = listing.isHidden === true;
+  const isHiddenOwnerView = isOwner && isHidden;
+
+  if (isHidden && !isOwner) {
+    return <ListingUnavailable />;
   }
 
   return (
     <ScrollView style={styles.container}>
+      {isHiddenOwnerView && <HiddenBanner />}
+
       <Text style={styles.title}>{listing.title}</Text>
       <Text style={styles.price}>${listing.price}</Text>
       <Text style={styles.description}>{listing.description}</Text>
@@ -55,7 +63,7 @@ export default function ListingDetailScreen() {
         </View>
       )}
 
-      {currentUserSubject && currentUserSubject === listing.sellerId && (
+      {isOwner && !isHidden && (
         <View style={styles.buttonContainer}>
           <TouchableOpacity
             style={styles.editButton}

--- a/frontend/app/listings/[id].tsx
+++ b/frontend/app/listings/[id].tsx
@@ -21,7 +21,7 @@ export default function ListingDetailScreen() {
     });
   };
 
-  if (listing === undefined) {
+  if (listing === undefined || currentUserSubject === undefined) {
     return (
       <View style={styles.container}>
         <Text>Loading...</Text>

--- a/frontend/app/listings/[id]/edit.tsx
+++ b/frontend/app/listings/[id]/edit.tsx
@@ -14,6 +14,7 @@ import { ConvexError } from 'convex/values';
 import { api } from 'convex/_generated/api';
 import { Id } from 'convex/_generated/dataModel';
 import TagInput from '../../../components/TagInput';
+import ListingUnavailable from '@/components/ListingUnavailable';
 
 type Category = 'textbooks' | 'electronics' | 'furniture' | 'tickets' | 'other';
 type Condition = 'new' | 'used' | 'refurbished';
@@ -76,8 +77,11 @@ export default function EditListingScreen() {
     }
   };
 
+  const isHidden = listing?.isHidden === true;
+
   const handleSubmit = async () => {
     if (!listing) return;
+    if (isHidden) return;
 
     // Validation
     const trimmedTitle = title.trim();
@@ -139,11 +143,11 @@ export default function EditListingScreen() {
   }
 
   if (listing === null) {
-    return (
-      <View style={styles.container}>
-        <Text>Listing not found</Text>
-      </View>
-    );
+    return <ListingUnavailable />;
+  }
+
+  if (isHidden) {
+    return <ListingUnavailable />;
   }
 
   return (

--- a/frontend/app/listings/[id]/edit.tsx
+++ b/frontend/app/listings/[id]/edit.tsx
@@ -14,7 +14,7 @@ import { ConvexError } from 'convex/values';
 import { api } from 'convex/_generated/api';
 import { Id } from 'convex/_generated/dataModel';
 import TagInput from '../../../components/TagInput';
-import ListingUnavailable from '@/components/ListingUnavailable';
+import ListingUnavailable from '../../../components/ListingUnavailable';
 
 type Category = 'textbooks' | 'electronics' | 'furniture' | 'tickets' | 'other';
 type Condition = 'new' | 'used' | 'refurbished';
@@ -142,11 +142,7 @@ export default function EditListingScreen() {
     );
   }
 
-  if (listing === null) {
-    return <ListingUnavailable />;
-  }
-
-  if (isHidden) {
+  if (listing === null || isHidden) {
     return <ListingUnavailable />;
   }
 

--- a/frontend/components/HiddenBanner.tsx
+++ b/frontend/components/HiddenBanner.tsx
@@ -1,0 +1,39 @@
+import { View, Text, StyleSheet, TouchableOpacity, Linking } from 'react-native';
+
+//Modify to actual support email
+const SUPPORT_EMAIL = 'support@polybuys.com';
+
+export default function HiddenBanner() {
+  const onAppealPress = () => Linking.openURL(`mailto:${SUPPORT_EMAIL}`);
+
+  return (
+    <View style={styles.banner}>
+      <Text style={styles.title}>This listing has been hidden due to reports.</Text>
+      <TouchableOpacity onPress={onAppealPress}>
+        <Text style={styles.link}>Contact support to appeal</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    backgroundColor: '#FFF8E1',
+    borderColor: '#F1C40F',
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 14,
+    color: '#5D4037',
+    marginBottom: 6,
+    fontWeight: '600',
+  },
+  link: {
+    fontSize: 14,
+    color: '#154734',
+    fontWeight: '600',
+  },
+});

--- a/frontend/components/HiddenBanner.tsx
+++ b/frontend/components/HiddenBanner.tsx
@@ -1,10 +1,13 @@
-import { View, Text, StyleSheet, TouchableOpacity, Linking } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, Linking, Alert } from 'react-native';
 
-//Modify to actual support email
-const SUPPORT_EMAIL = 'support@polybuys.com';
+const SUPPORT_EMAIL = process.env.EXPO_PUBLIC_SUPPORT_EMAIL?.trim() || 'support@polybuys.com';
 
 export default function HiddenBanner() {
-  const onAppealPress = () => Linking.openURL(`mailto:${SUPPORT_EMAIL}`);
+  const onAppealPress = () => {
+    Linking.openURL(`mailto:${SUPPORT_EMAIL}`).catch(() => {
+      Alert.alert('Unable to open email app', `Please contact support at ${SUPPORT_EMAIL}.`);
+    });
+  };
 
   return (
     <View style={styles.banner}>

--- a/frontend/components/ListingUnavailable.tsx
+++ b/frontend/components/ListingUnavailable.tsx
@@ -1,0 +1,33 @@
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { useRouter } from 'expo-router';
+
+export default function ListingUnavailable() {
+  const router = useRouter();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>This listing is no longer available</Text>
+      <TouchableOpacity style={styles.button} onPress={() => router.replace('/')}>
+        <Text style={styles.buttonText}>Back to Browse</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+    backgroundColor: '#fff',
+  },
+  title: { fontSize: 20, fontWeight: '600', color: '#333', textAlign: 'center', marginBottom: 16 },
+  button: {
+    backgroundColor: '#154734',
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    borderRadius: 8,
+  },
+  buttonText: { color: '#fff', fontWeight: '600' },
+});


### PR DESCRIPTION
## Linked Issues

Closes #22
Linear: POLY-22

## Summary

Implemented hidden-listing handling in the frontend so moderated content is not shown in normal browse flows.

Changes:

Added ListingUnavailable component with:
- message: “This listing is no longer available”
- “Back to Browse” button

Added reusable HiddenBanner for owner-only hidden listing view

Updated listing detail screen to:
- show unavailable state for non-owners on hidden listings
- show banner + listing content for owners on hidden listings
- hide edit action when listing is hidden

Added defensive client-side filtering in home feed to exclude hidden listings

## How to Test

Steps to verify locally:

- `npm run lint`
- `npm run typecheck`
- `npm test`
- Manual flow:
  1. `npm run dev:backend` (in terminal A)
  2. `npm run dev` (in terminal B)
  3. Verify the change: <describe expected behavior/screens>

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Lint/tests pass locally (`npm run lint`)
- [ ] Docs updated (README/ADR/changelog if needed)
- [ ] Follows conventional commit format
- [ ] No merge conflicts with `dev`

## Screenshots / Demos

Still requires testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hidden listings are now excluded from the main browse list.
  * Non-owners see an "unavailable" screen with a Back to Browse button for hidden listings.
  * Listing owners viewing their hidden listings see a notification banner.
  * Owners are prevented from editing listings while hidden.
  * A support/appeal contact link is provided from the hidden-listing banner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->