### PR TITLE
Stale request bug

### DIFF
--- a/backend/convex/listings.ts
+++ b/backend/convex/listings.ts
@@ -430,6 +430,8 @@ export const getListings = query({
       numItems: v.number(),
       cursor: v.union(v.string(), v.null()),
     }),
+    /** Optional key bumped by the client to force a refetch when cursor is already null */
+    _refreshKey: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     // Validate pagination bounds to prevent DoS

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -50,6 +50,7 @@ export default function HomeScreen() {
   const [isDone, setIsDone] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
 
   // Filter versioning to prevent stale results
   const filterVersionRef = useRef(0);
@@ -83,10 +84,13 @@ export default function HomeScreen() {
     maxPrice: filters.maxPrice,
     tags: selectedTags.length > 0 ? selectedTags : undefined,
     paginationOpts: { numItems: PAGE_SIZE, cursor },
+    _refreshKey: refreshKey,
   });
 
-  // Reset pagination and refetch first page (used by pull-to-refresh and focus)
+  // Reset pagination and refetch first page (used by pull-to-refresh and focus).
+  // Bumping refreshKey forces Convex to re-run when cursor is already null.
   const refreshListings = useCallback(() => {
+    setRefreshKey((k) => k + 1);
     setCursor(null);
     processedCursorsRef.current.clear();
   }, []);
@@ -185,6 +189,11 @@ export default function HomeScreen() {
       setCursor(listingsResult.continueCursor);
     }
   }, [isDone, isLoadingMore, listingsResult?.continueCursor]);
+
+  const handleRefresh = useCallback(() => {
+    setRefreshing(true);
+    refreshListings();
+  }, [refreshListings]);
 
   const handleCreateListing = () => {
     if (!isAuthenticated) {
@@ -285,10 +294,7 @@ export default function HomeScreen() {
             refreshControl={
               <RefreshControl
                 refreshing={refreshing}
-                onRefresh={() => {
-                  setRefreshing(true);
-                  refreshListings();
-                }}
+                onRefresh={handleRefresh}
                 colors={['#154734']}
                 tintColor="#154734"
               />

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -5,6 +5,7 @@ import {
   FlatList,
   Platform,
   Pressable,
+  RefreshControl,
   StyleSheet,
   Text,
   View,
@@ -12,7 +13,7 @@ import {
 } from 'react-native';
 import { useQuery } from 'convex/react';
 import { api } from 'convex/_generated/api';
-import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { FilterBar } from '../../components/FilterBar';
@@ -46,6 +47,7 @@ export default function HomeScreen() {
   const [cursor, setCursor] = useState<string | null>(null);
   const [isDone, setIsDone] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
 
   // Filter versioning to prevent stale results
   const filterVersionRef = useRef(0);
@@ -79,12 +81,19 @@ export default function HomeScreen() {
     paginationOpts: { numItems: PAGE_SIZE, cursor },
   });
 
+  // Reset pagination and refetch first page (used by pull-to-refresh and focus)
+  const refreshListings = useCallback(() => {
+    setCursor(null);
+    processedCursorsRef.current.clear();
+  }, []);
+
   useEffect(() => {
     if (listingsResult && queryFilterVersion === filterVersionRef.current) {
       const cursorId = cursor || 'initial';
       if (!processedCursorsRef.current.has(cursorId)) {
         if (cursor === null) {
           setAllListings(listingsResult.page);
+          setRefreshing(false);
         } else {
           setAllListings((prev) => [...prev, ...listingsResult.page]);
         }
@@ -103,6 +112,13 @@ export default function HomeScreen() {
     setIsDone(false);
     processedCursorsRef.current.clear();
   }, [filters.category, filters.minPrice, filters.maxPrice, selectedTags]);
+
+  // Refetch first page when returning to Home so listings stay fresh
+  useFocusEffect(
+    useCallback(() => {
+      refreshListings();
+    }, [refreshListings])
+  );
 
   const listings = allListings.filter((listing) => listing.isHidden !== true);
 
@@ -251,6 +267,17 @@ export default function HomeScreen() {
             contentContainerStyle={styles.listContainer}
             onEndReached={handleLoadMore}
             onEndReachedThreshold={0.5}
+            refreshControl={
+              <RefreshControl
+                refreshing={refreshing}
+                onRefresh={() => {
+                  setRefreshing(true);
+                  refreshListings();
+                }}
+                colors={['#154734']}
+                tintColor="#154734"
+              />
+            }
             ListFooterComponent={
               isLoadingMore ? (
                 <View style={styles.footerLoader}>

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -104,6 +104,13 @@ export default function HomeScreen() {
     }
   }, [listingsResult, cursor, queryFilterVersion]);
 
+  // Stop refresh spinner if the query never returns (e.g. network failure)
+  useEffect(() => {
+    if (!refreshing || cursor !== null) return;
+    const fallback = setTimeout(() => setRefreshing(false), 15000);
+    return () => clearTimeout(fallback);
+  }, [refreshing, cursor]);
+
   useEffect(() => {
     filterVersionRef.current += 1;
     currentFilterVersionRef.current = filterVersionRef.current;

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -26,6 +26,8 @@ import type { Doc } from 'convex/_generated/dataModel';
 import { useEntranceAnimation } from '../../hooks/useEntranceAnimation';
 
 const PAGE_SIZE = 20;
+/** Only refetch on focus when data is older than this (avoids redundant queries and preserves scroll/pagination) */
+const FOCUS_REFETCH_STALE_MS = 45_000;
 
 export default function HomeScreen() {
   const router = useRouter();
@@ -55,6 +57,8 @@ export default function HomeScreen() {
 
   // Track processed cursors to avoid duplicate appends
   const processedCursorsRef = useRef(new Set<string>());
+  // When we last received the first page (for focus-based staleness check)
+  const lastFirstPageAtRef = useRef<number>(0);
 
   // Initialize selected tags from URL params
   useEffect(() => {
@@ -94,6 +98,7 @@ export default function HomeScreen() {
         if (cursor === null) {
           setAllListings(listingsResult.page);
           setRefreshing(false);
+          lastFirstPageAtRef.current = Date.now();
         } else {
           setAllListings((prev) => [...prev, ...listingsResult.page]);
         }
@@ -120,10 +125,13 @@ export default function HomeScreen() {
     processedCursorsRef.current.clear();
   }, [filters.category, filters.minPrice, filters.maxPrice, selectedTags]);
 
-  // Refetch first page when returning to Home so listings stay fresh
+  // Refetch when returning to Home only if data is stale (avoids redundant queries, preserves scroll/pagination)
   useFocusEffect(
     useCallback(() => {
-      refreshListings();
+      const last = lastFirstPageAtRef.current;
+      if (last > 0 && Date.now() - last > FOCUS_REFETCH_STALE_MS) {
+        refreshListings();
+      }
     }, [refreshListings])
   );
 


### PR DESCRIPTION
## Linked Issues
Fixed the stale request bug
Closes #51
Linear: POLY-48

## Summary

Just had to add a refresh control tool so that whenever home is accessed, it reloads the page so no more stale pages

## How to Test

Steps to verify locally:

- `npm run lint`
- `npm run typecheck`
- `npm test`
- Manual flow:
  1. `npm run dev:backend` (in terminal A)
  2. `npm run dev` (in terminal B)
  3. Verify the change: <describe expected behavior/screens>

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Lint/tests pass locally (`npm run lint`)
- [ ] Docs updated (README/ADR/changelog if needed)
- [ ] Follows conventional commit format
- [ ] No merge conflicts with `dev`

## Screenshots / Demos

(if UI or visible behavior - attach images, videos, or GIFs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pull-to-refresh on the home listings screen for manual refresh.
  * Listings now auto-refresh when returning to the home screen if data is stale.
  * Built-in timeout to stop prolonged loading during refresh.
  * Filter changes reset listings to show updated results; automatic refreshes avoid disturbing current pagination when possible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->