### PR TITLE
Build messaging & inbox UI & message seller button

### DIFF
--- a/backend/convex/__tests__/messages.test.ts
+++ b/backend/convex/__tests__/messages.test.ts
@@ -15,6 +15,7 @@ jest.mock('@convex-dev/expo-push-notifications', () => {
 import { api, internal } from '../_generated/api';
 import {
   createConvexTest,
+  createTestProfile,
   createTestUser,
   createTestListing,
   createTestConversation,
@@ -369,6 +370,40 @@ describe('Messages queries and mutations', () => {
 
       expect(conversations).toHaveLength(2);
       expect(conversations[0].updatedAt).toBeGreaterThan(conversations[1].updatedAt);
+    });
+
+    it('resolves other user name for aliased participant ids', async () => {
+      const t = createConvexTest();
+
+      const buyer = await createTestUser(t, 'buyer@calpoly.edu', 'Buyer');
+      const seller = await createTestUser(t, 'seller@calpoly.edu', 'Seller');
+      const listingId = await createTestListing(t, seller.id);
+
+      await createTestProfile(t, `${buyer.id}|profile-alias`, {
+        name: 'Buyer Profile Name',
+        email: 'buyer@calpoly.edu',
+      });
+
+      await t.run(async (ctx) => {
+        await ctx.db.patch(buyer.id, { name: '' });
+        const now = Date.now();
+        await ctx.db.insert('conversations', {
+          listingId,
+          buyerId: `${buyer.id}|conversation-alias`,
+          sellerId: seller.id,
+          participantIds: [`${buyer.id}|conversation-alias`, seller.id],
+          createdAt: now,
+          updatedAt: now,
+          buyerLastReadAt: now,
+          sellerLastReadAt: now,
+        });
+      });
+
+      const asSeller = t.withIdentity(seller.identity);
+      const conversations = await asSeller.query(api.messages.listUserConversations);
+
+      expect(conversations).toHaveLength(1);
+      expect(conversations[0].otherUser.name).toBe('Buyer Profile Name');
     });
   });
 

--- a/backend/convex/__tests__/messages.test.ts
+++ b/backend/convex/__tests__/messages.test.ts
@@ -67,6 +67,23 @@ describe('Messages queries and mutations', () => {
       }).rejects.toThrow('Forbidden');
     });
 
+    it('rejects whitespace-only message bodies', async () => {
+      const t = createConvexTest();
+
+      const buyer = await createTestUser(t, 'buyer@calpoly.edu', 'Buyer');
+      const seller = await createTestUser(t, 'seller@calpoly.edu', 'Seller');
+      const listingId = await createTestListing(t, seller.id);
+      const conversationId = await createTestConversation(t, listingId, buyer.id, seller.id);
+
+      const asBuyer = t.withIdentity(buyer.identity);
+      await expect(async () => {
+        await asBuyer.action(api.messages.sendMessage, {
+          conversationId,
+          body: '   \n\t  ',
+        });
+      }).rejects.toThrow('Message cannot be empty');
+    });
+
     it('successfully sends message from buyer to seller', async () => {
       const t = createConvexTest();
 
@@ -275,6 +292,62 @@ describe('Messages queries and mutations', () => {
       expect(messages[1].body).toBe('Second message');
       expect(messages[2].body).toBe('Third message');
     });
+
+    it('aggregates messages across siblingConversationIds', async () => {
+      const t = createConvexTest();
+
+      const buyer = await createTestUser(t, 'buyer@calpoly.edu', 'Buyer');
+      const seller = await createTestUser(t, 'seller@calpoly.edu', 'Seller');
+      const listingId = await createTestListing(t, seller.id);
+      const primaryConversationId = await createTestConversation(t, listingId, buyer.id, seller.id);
+      const siblingConversationId = await t.run(async (ctx) => {
+        const now = Date.now();
+        return await ctx.db.insert('conversations', {
+          listingId,
+          buyerId: `${buyer.id}|legacy-buyer`,
+          sellerId: seller.id,
+          participantIds: [`${buyer.id}|legacy-buyer`, seller.id],
+          createdAt: now + 1,
+          updatedAt: now + 1,
+          buyerLastReadAt: now + 1,
+          sellerLastReadAt: now + 1,
+        });
+      });
+
+      await t.run(async (ctx) => {
+        await ctx.db.insert('messages', {
+          conversationId: primaryConversationId,
+          listingId,
+          senderId: buyer.id,
+          recipientId: seller.id,
+          type: 'text',
+          body: 'Primary thread message',
+          createdAt: Date.now(),
+          readAt: 0,
+        });
+
+        await ctx.db.insert('messages', {
+          conversationId: siblingConversationId,
+          listingId,
+          senderId: `${buyer.id}|legacy-buyer`,
+          recipientId: seller.id,
+          type: 'text',
+          body: 'Sibling thread message',
+          createdAt: Date.now() + 1000,
+          readAt: 0,
+        });
+      });
+
+      const asSeller = t.withIdentity(seller.identity);
+      const messages = await asSeller.query(api.messages.getConversationHistory, {
+        conversationId: primaryConversationId,
+        siblingConversationIds: [siblingConversationId],
+      });
+
+      expect(messages).toHaveLength(2);
+      expect(messages[0].body).toBe('Primary thread message');
+      expect(messages[1].body).toBe('Sibling thread message');
+    });
   });
 
   describe('listUserConversations', () => {
@@ -404,6 +477,29 @@ describe('Messages queries and mutations', () => {
 
       expect(conversations).toHaveLength(1);
       expect(conversations[0].otherUser.name).toBe('Buyer Profile Name');
+    });
+
+    it('returns generic user label when no public name is available', async () => {
+      const t = createConvexTest();
+
+      const buyer = await createTestUser(t, 'buyer@calpoly.edu', 'Buyer');
+      const seller = await createTestUser(t, 'seller@calpoly.edu', 'Seller');
+      const listingId = await createTestListing(t, seller.id);
+
+      await t.run(async (ctx) => {
+        await ctx.db.patch(buyer.id, { name: '' });
+      });
+      await createTestProfile(t, buyer.id, {
+        name: '',
+        email: 'private-buyer@calpoly.edu',
+      });
+      await createTestConversation(t, listingId, buyer.id, seller.id);
+
+      const asSeller = t.withIdentity(seller.identity);
+      const conversations = await asSeller.query(api.messages.listUserConversations);
+
+      expect(conversations).toHaveLength(1);
+      expect(conversations[0].otherUser.name).toBe('User');
     });
   });
 
@@ -662,6 +758,67 @@ describe('Messages queries and mutations', () => {
       expect(message!.readAt).toBeGreaterThan(0);
     });
 
+    it('marks unread messages as read across siblingConversationIds', async () => {
+      const t = createConvexTest();
+
+      const buyer = await createTestUser(t, 'buyer@calpoly.edu', 'Buyer');
+      const seller = await createTestUser(t, 'seller@calpoly.edu', 'Seller');
+      const listingId = await createTestListing(t, seller.id);
+      const primaryConversationId = await createTestConversation(t, listingId, buyer.id, seller.id);
+      const siblingConversationId = await t.run(async (ctx) => {
+        const now = Date.now();
+        return await ctx.db.insert('conversations', {
+          listingId,
+          buyerId: `${buyer.id}|legacy-buyer`,
+          sellerId: seller.id,
+          participantIds: [`${buyer.id}|legacy-buyer`, seller.id],
+          createdAt: now + 1,
+          updatedAt: now + 1,
+          buyerLastReadAt: now + 1,
+          sellerLastReadAt: now + 1,
+        });
+      });
+
+      const [primaryMessageId, siblingMessageId] = await t.run(async (ctx) => {
+        const firstId = await ctx.db.insert('messages', {
+          conversationId: primaryConversationId,
+          listingId,
+          senderId: buyer.id,
+          recipientId: seller.id,
+          type: 'text',
+          body: 'Unread in primary',
+          createdAt: Date.now(),
+          readAt: 0,
+        });
+        const secondId = await ctx.db.insert('messages', {
+          conversationId: siblingConversationId,
+          listingId,
+          senderId: `${buyer.id}|legacy-buyer`,
+          recipientId: seller.id,
+          type: 'text',
+          body: 'Unread in sibling',
+          createdAt: Date.now() + 1000,
+          readAt: 0,
+        });
+        return [firstId, secondId] as const;
+      });
+
+      const asSeller = t.withIdentity(seller.identity);
+      await asSeller.mutation(api.messages.markMessagesAsRead, {
+        conversationId: primaryConversationId,
+        siblingConversationIds: [siblingConversationId],
+      });
+
+      const [primaryMessage, siblingMessage] = await t.run(async (ctx) => {
+        const first = await ctx.db.get(primaryMessageId);
+        const second = await ctx.db.get(siblingMessageId);
+        return [first, second] as const;
+      });
+
+      expect(primaryMessage!.readAt).toBeGreaterThan(0);
+      expect(siblingMessage!.readAt).toBeGreaterThan(0);
+    });
+
     it('does not mark messages sent by the user as read', async () => {
       const t = createConvexTest();
 
@@ -757,6 +914,62 @@ describe('Messages queries and mutations', () => {
       expect(messages).toHaveLength(2);
       expect(messages[0].body).toBe('Message 1');
       expect(messages[1].body).toBe('Message 2');
+    });
+
+    it('returns messages across siblingConversationIds', async () => {
+      const t = createConvexTest();
+
+      const buyer = await createTestUser(t, 'buyer@calpoly.edu', 'Buyer');
+      const seller = await createTestUser(t, 'seller@calpoly.edu', 'Seller');
+      const listingId = await createTestListing(t, seller.id);
+      const primaryConversationId = await createTestConversation(t, listingId, buyer.id, seller.id);
+      const siblingConversationId = await t.run(async (ctx) => {
+        const now = Date.now();
+        return await ctx.db.insert('conversations', {
+          listingId,
+          buyerId: `${buyer.id}|legacy-buyer`,
+          sellerId: seller.id,
+          participantIds: [`${buyer.id}|legacy-buyer`, seller.id],
+          createdAt: now + 1,
+          updatedAt: now + 1,
+          buyerLastReadAt: now + 1,
+          sellerLastReadAt: now + 1,
+        });
+      });
+
+      await t.run(async (ctx) => {
+        await ctx.db.insert('messages', {
+          conversationId: primaryConversationId,
+          listingId,
+          senderId: buyer.id,
+          recipientId: seller.id,
+          type: 'text',
+          body: 'Primary 1',
+          createdAt: Date.now(),
+          readAt: 0,
+        });
+
+        await ctx.db.insert('messages', {
+          conversationId: siblingConversationId,
+          listingId,
+          senderId: `${buyer.id}|legacy-buyer`,
+          recipientId: seller.id,
+          type: 'text',
+          body: 'Sibling 1',
+          createdAt: Date.now() + 1000,
+          readAt: 0,
+        });
+      });
+
+      const asSeller = t.withIdentity(seller.identity);
+      const messages = await asSeller.query(api.messages.messagesByConversation, {
+        conversationId: primaryConversationId,
+        siblingConversationIds: [siblingConversationId],
+      });
+
+      expect(messages).toHaveLength(2);
+      expect(messages[0].body).toBe('Primary 1');
+      expect(messages[1].body).toBe('Sibling 1');
     });
   });
 

--- a/backend/convex/__tests__/messages.test.ts
+++ b/backend/convex/__tests__/messages.test.ts
@@ -600,6 +600,34 @@ describe('Messages queries and mutations', () => {
       expect(conversationAfter!.sellerLastReadAt).toBeGreaterThan(oldSellerLastReadAt);
     });
 
+    it('does not update conversation updatedAt when marking messages as read', async () => {
+      const t = createConvexTest();
+
+      const buyer = await createTestUser(t, 'buyer@calpoly.edu', 'Buyer');
+      const seller = await createTestUser(t, 'seller@calpoly.edu', 'Seller');
+      const listingId = await createTestListing(t, seller.id);
+      const conversationId = await createTestConversation(t, listingId, buyer.id, seller.id);
+
+      const asBuyer = t.withIdentity(buyer.identity);
+      const conversationBefore = await t.run(async (ctx) => {
+        return await ctx.db.get(conversationId);
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      await asBuyer.mutation(api.messages.markMessagesAsRead, {
+        conversationId,
+      });
+
+      const conversationAfter = await t.run(async (ctx) => {
+        return await ctx.db.get(conversationId);
+      });
+
+      expect(conversationAfter!.updatedAt).toBe(conversationBefore!.updatedAt);
+      expect(conversationAfter!.buyerLastReadAt).toBeGreaterThan(
+        conversationBefore!.buyerLastReadAt
+      );
+    });
+
     it('marks unread messages as read for buyer', async () => {
       const t = createConvexTest();
 

--- a/backend/convex/messages.ts
+++ b/backend/convex/messages.ts
@@ -1,12 +1,26 @@
 import { internalMutation, mutation, query, action, internalQuery } from './_generated/server';
+import { getAuthUserId } from '@convex-dev/auth/server';
 import { v, ConvexError } from 'convex/values';
 import type { MutationCtx, QueryCtx } from './_generated/server';
-import type { Id } from './_generated/dataModel';
-import { internal } from './_generated/api';
+import type { Doc, Id } from './_generated/dataModel';
+import { api, internal } from './_generated/api';
 
 export const PAYLOAD_BOUNDS = {
   MESSAGE_MAX: 2000,
 };
+
+function canonicalParticipantId(value: string) {
+  const [base] = value.split('|');
+  return base;
+}
+
+function isSameParticipantId(left: string, right: string) {
+  return left === right || canonicalParticipantId(left) === canonicalParticipantId(right);
+}
+
+function matchesAnyParticipantId(value: string, candidates: string[]) {
+  return candidates.some((candidate) => isSameParticipantId(value, candidate));
+}
 
 function isRemoteUrl(value: string) {
   return value.startsWith('http://') || value.startsWith('https://');
@@ -14,9 +28,20 @@ function isRemoteUrl(value: string) {
 
 function displayNameFromProfile(
   profile: { name?: string; email?: string; userId?: string } | null,
+  user: { name?: string; email?: string } | null,
   fallbackUserId: string
 ) {
+  const userName = user?.name?.trim();
+  if (userName && userName.length > 0) {
+    return userName;
+  }
+
   if (!profile) {
+    const userEmail = user?.email?.trim().toLowerCase();
+    if (userEmail && userEmail.includes('@')) {
+      return userEmail.split('@')[0];
+    }
+
     const normalized = fallbackUserId.trim().toLowerCase();
     if (normalized.includes('@')) {
       return normalized.split('@')[0];
@@ -35,6 +60,19 @@ function displayNameFromProfile(
   }
 
   return 'User';
+}
+
+async function getParticipantKeys(ctx: MutationCtx | QueryCtx): Promise<string[]> {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) throw new ConvexError('Unauthorized');
+
+  const keys = new Set<string>([identity.subject]);
+  const authUserId = await getAuthUserId(ctx);
+  if (authUserId) {
+    keys.add(authUserId);
+  }
+
+  return [...keys];
 }
 
 // Internal query: get conversation and verify user is a participant (used by sendMessage action)
@@ -101,6 +139,11 @@ export const sendMessage = action({
       throw new ConvexError('Unauthorized');
     }
     const userId = identity.subject;
+    const currentUser = await ctx.runQuery(api.users.getCurrentUser, {});
+    const senderParticipantKeys = new Set<string>([userId]);
+    if (currentUser?._id) {
+      senderParticipantKeys.add(currentUser._id);
+    }
 
     // Participant check via internal query
     const convo = await ctx.runQuery(internal.messages.internalGetConversation, {
@@ -110,13 +153,14 @@ export const sendMessage = action({
       throw new ConvexError('Conversation not found');
     }
 
-    const isBuyer = convo.buyerId === userId;
-    const isSeller = convo.sellerId === userId;
-    if (!isBuyer && !isSeller) {
+    const isBuyerByAlias = matchesAnyParticipantId(convo.buyerId, [...senderParticipantKeys]);
+    const isSellerByAlias = matchesAnyParticipantId(convo.sellerId, [...senderParticipantKeys]);
+    if (!isBuyerByAlias && !isSellerByAlias) {
       throw new ConvexError('Forbidden');
     }
 
-    const recipientId = userId === convo.buyerId ? convo.sellerId : convo.buyerId;
+    const senderId = isBuyerByAlias ? convo.buyerId : convo.sellerId;
+    const recipientId = isBuyerByAlias ? convo.sellerId : convo.buyerId;
 
     // Screen content via OpenAI Moderation API
     const moderationResult = await ctx.runAction(internal.moderation.moderateContent, {
@@ -133,7 +177,7 @@ export const sendMessage = action({
     const result = await ctx.runMutation(internal.messages.internalSendMessage, {
       conversationId: args.conversationId,
       listingId: convo.listingId,
-      senderId: userId,
+      senderId,
       recipientId,
       body: args.body,
       type: type,
@@ -219,29 +263,37 @@ export const getConversationHistory = query({
 export const listUserConversations = query({
   args: {},
   handler: async (ctx) => {
-    const userId = await getUserId(ctx);
-    const buyerConvos = await ctx.db
-      .query('conversations')
-      .withIndex('by_buyer', (q) => q.eq('buyerId', userId))
-      .order('desc')
-      .collect();
+    const participantKeys = await getParticipantKeys(ctx);
+    const allConversations = await ctx.db.query('conversations').collect();
+    const participantConversations = allConversations
+      .filter(
+        (conversation) =>
+          matchesAnyParticipantId(conversation.buyerId, participantKeys) ||
+          matchesAnyParticipantId(conversation.sellerId, participantKeys)
+      )
+      .sort((a, b) => b.updatedAt - a.updatedAt);
 
-    const sellerConvos = await ctx.db
-      .query('conversations')
-      .withIndex('by_seller', (q) => q.eq('sellerId', userId))
-      .order('desc')
-      .collect();
-
-    const conversations = [...buyerConvos, ...sellerConvos].sort(
+    // Legacy compatibility: collapse duplicate threads created with aliased participant IDs.
+    const dedupedConversationMap = new Map<string, Doc<'conversations'>>();
+    for (const conversation of participantConversations) {
+      const isBuyer = matchesAnyParticipantId(conversation.buyerId, participantKeys);
+      const otherUserId = isBuyer ? conversation.sellerId : conversation.buyerId;
+      const dedupeKey = `${conversation.listingId}:${canonicalParticipantId(otherUserId)}`;
+      const existing = dedupedConversationMap.get(dedupeKey);
+      if (!existing || conversation.updatedAt > existing.updatedAt) {
+        dedupedConversationMap.set(dedupeKey, conversation);
+      }
+    }
+    const conversations = [...dedupedConversationMap.values()].sort(
       (a, b) => b.updatedAt - a.updatedAt
     );
 
     return await Promise.all(
       conversations.map(async (conversation) => {
-        const otherUserId =
-          conversation.buyerId === userId ? conversation.sellerId : conversation.buyerId;
+        const isBuyer = matchesAnyParticipantId(conversation.buyerId, participantKeys);
+        const otherUserId = isBuyer ? conversation.sellerId : conversation.buyerId;
 
-        const [otherProfile, listing, unreadMessage, latestMessage] = await Promise.all([
+        const [otherProfile, listing, latestMessage, unreadMessages] = await Promise.all([
           ctx.db
             .query('profiles')
             .withIndex('by_userId', (q) => q.eq('userId', otherUserId))
@@ -249,16 +301,20 @@ export const listUserConversations = query({
           ctx.db.get(conversation.listingId),
           ctx.db
             .query('messages')
-            .withIndex('by_conversation_recipient_readAt', (q) =>
-              q.eq('conversationId', conversation._id).eq('recipientId', userId).eq('readAt', 0)
-            )
-            .first(),
-          ctx.db
-            .query('messages')
             .withIndex('by_conversation_createdAt', (q) => q.eq('conversationId', conversation._id))
             .order('desc')
             .first(),
+          ctx.db
+            .query('messages')
+            .withIndex('by_conversation_recipient_readAt', (q) =>
+              q.eq('conversationId', conversation._id)
+            )
+            .filter((q) => q.eq(q.field('readAt'), 0))
+            .collect(),
         ]);
+
+        const normalizedOtherUserId = await ctx.db.normalizeId('users', otherUserId);
+        const otherUserDoc = normalizedOtherUserId ? await ctx.db.get(normalizedOtherUserId) : null;
 
         const thumbnailSource = listing?.images?.[0] ?? null;
         let listingThumbnailUrl: string | null = null;
@@ -278,7 +334,7 @@ export const listUserConversations = query({
           ...conversation,
           otherUser: {
             id: otherUserId,
-            name: displayNameFromProfile(otherProfile, otherUserId),
+            name: displayNameFromProfile(otherProfile, otherUserDoc, otherUserId),
           },
           listing: {
             id: conversation.listingId,
@@ -287,32 +343,29 @@ export const listUserConversations = query({
           },
           lastMessagePreview: latestMessage?.body ?? 'Conversation started',
           lastMessageAt: latestMessage?.createdAt ?? conversation.updatedAt,
-          hasUnread: unreadMessage !== null,
+          hasUnread: unreadMessages.some((message) =>
+            matchesAnyParticipantId(message.recipientId, participantKeys)
+          ),
         };
       })
     );
   },
 });
 
-async function getUserId(ctx: MutationCtx | QueryCtx): Promise<string> {
-  const identity = await ctx.auth.getUserIdentity();
-  if (!identity) throw new ConvexError('Unauthorized');
-  return identity.subject;
-}
-
 async function requireParticipant(
   ctx: MutationCtx | QueryCtx,
   conversationId: Id<'conversations'>
 ) {
-  const userId = await getUserId(ctx);
+  const participantKeys = await getParticipantKeys(ctx);
+  const userId = participantKeys[0];
   const convo = await ctx.db.get(conversationId);
   if (!convo) throw new ConvexError('Conversation not found');
 
-  const isBuyer = convo.buyerId === userId;
-  const isSeller = convo.sellerId === userId;
+  const isBuyer = matchesAnyParticipantId(convo.buyerId, participantKeys);
+  const isSeller = matchesAnyParticipantId(convo.sellerId, participantKeys);
   if (!isBuyer && !isSeller) throw new ConvexError('Forbidden');
 
-  return { userId, convo, isBuyer, isSeller };
+  return { userId, participantKeys, convo, isBuyer, isSeller };
 }
 
 export const getOrCreateConversation = mutation({
@@ -320,7 +373,8 @@ export const getOrCreateConversation = mutation({
     listingId: v.id('listings'),
   },
   handler: async (ctx, args) => {
-    const buyerId = await getUserId(ctx);
+    const buyerParticipantKeys = await getParticipantKeys(ctx);
+    const buyerId = buyerParticipantKeys[0];
 
     const listing = await ctx.db.get(args.listingId);
     if (!listing) throw new ConvexError('Listing not found');
@@ -334,17 +388,38 @@ export const getOrCreateConversation = mutation({
     }
 
     const sellerId = listing.sellerId;
-    if (buyerId === sellerId) throw new ConvexError("You can't message yourself");
+    if (matchesAnyParticipantId(sellerId, buyerParticipantKeys)) {
+      throw new ConvexError("You can't message yourself");
+    }
 
-    const existing = await ctx.db
+    for (const buyerKey of buyerParticipantKeys) {
+      const existing = await ctx.db
+        .query('conversations')
+        .withIndex('by_listing_buyer_seller', (q) =>
+          q.eq('listingId', args.listingId).eq('buyerId', buyerKey)
+        )
+        .filter((q) => q.eq(q.field('sellerId'), sellerId))
+        .first();
+
+      if (existing) return { conversationId: existing._id };
+    }
+
+    const listingConversations = await ctx.db
       .query('conversations')
-      .withIndex('by_listing_buyer_seller', (q) =>
-        q.eq('listingId', args.listingId).eq('buyerId', buyerId)
-      )
-      .filter((q) => q.eq(q.field('sellerId'), sellerId))
-      .first();
+      .withIndex('by_listing', (q) => q.eq('listingId', args.listingId))
+      .collect();
 
-    if (existing) return { conversationId: existing._id };
+    const aliasMatches = listingConversations
+      .filter(
+        (conversation) =>
+          matchesAnyParticipantId(conversation.buyerId, buyerParticipantKeys) &&
+          isSameParticipantId(conversation.sellerId, sellerId)
+      )
+      .sort((a, b) => b.updatedAt - a.updatedAt);
+    const aliasMatch = aliasMatches[0];
+    if (aliasMatch) {
+      return { conversationId: aliasMatch._id };
+    }
 
     const now = Date.now();
     const conversationId = await ctx.db.insert('conversations', {
@@ -368,7 +443,10 @@ export const markMessagesAsRead = mutation({
     conversationId: v.id('conversations'),
   },
   handler: async (ctx, args) => {
-    const { userId, convo, isBuyer, isSeller } = await requireParticipant(ctx, args.conversationId);
+    const { convo, participantKeys, isBuyer, isSeller } = await requireParticipant(
+      ctx,
+      args.conversationId
+    );
 
     const now = Date.now();
 
@@ -383,12 +461,13 @@ export const markMessagesAsRead = mutation({
       .withIndex('by_conversation_recipient_readAt', (q) =>
         q.eq('conversationId', args.conversationId)
       )
-      .filter((q) => q.eq(q.field('recipientId'), userId))
       .filter((q) => q.eq(q.field('readAt'), 0))
       .collect();
 
     for (const msg of unread) {
-      await ctx.db.patch(msg._id, { readAt: now });
+      if (matchesAnyParticipantId(msg.recipientId, participantKeys)) {
+        await ctx.db.patch(msg._id, { readAt: now });
+      }
     }
 
     return { ok: true };

--- a/backend/convex/messages.ts
+++ b/backend/convex/messages.ts
@@ -288,16 +288,31 @@ export const listUserConversations = query({
       (a, b) => b.updatedAt - a.updatedAt
     );
 
+    const allProfiles = await ctx.db.query('profiles').collect();
+    const profilesByCanonicalUserId = new Map<string, Doc<'profiles'>>();
+    for (const profile of allProfiles) {
+      const canonicalUserId = canonicalParticipantId(profile.userId);
+      if (!profilesByCanonicalUserId.has(canonicalUserId)) {
+        profilesByCanonicalUserId.set(canonicalUserId, profile);
+      }
+    }
+
+    const userDocsByCanonicalUserId = new Map<string, Doc<'users'> | null>();
+
     return await Promise.all(
       conversations.map(async (conversation) => {
         const isBuyer = matchesAnyParticipantId(conversation.buyerId, participantKeys);
         const otherUserId = isBuyer ? conversation.sellerId : conversation.buyerId;
+        const canonicalOtherUserId = canonicalParticipantId(otherUserId);
 
-        const [otherProfile, listing, latestMessage, unreadMessages] = await Promise.all([
-          ctx.db
-            .query('profiles')
-            .withIndex('by_userId', (q) => q.eq('userId', otherUserId))
-            .first(),
+        let otherUserDoc = userDocsByCanonicalUserId.get(canonicalOtherUserId);
+        if (otherUserDoc === undefined) {
+          const normalizedOtherUserId = await ctx.db.normalizeId('users', canonicalOtherUserId);
+          otherUserDoc = normalizedOtherUserId ? await ctx.db.get(normalizedOtherUserId) : null;
+          userDocsByCanonicalUserId.set(canonicalOtherUserId, otherUserDoc);
+        }
+
+        const [listing, latestMessage, unreadMessages] = await Promise.all([
           ctx.db.get(conversation.listingId),
           ctx.db
             .query('messages')
@@ -312,9 +327,7 @@ export const listUserConversations = query({
             .filter((q) => q.eq(q.field('readAt'), 0))
             .collect(),
         ]);
-
-        const normalizedOtherUserId = await ctx.db.normalizeId('users', otherUserId);
-        const otherUserDoc = normalizedOtherUserId ? await ctx.db.get(normalizedOtherUserId) : null;
+        const otherProfile = profilesByCanonicalUserId.get(canonicalOtherUserId) ?? null;
 
         const thumbnailSource = listing?.images?.[0] ?? null;
         let listingThumbnailUrl: string | null = null;

--- a/backend/convex/messages.ts
+++ b/backend/convex/messages.ts
@@ -343,6 +343,9 @@ export const listUserConversations = query({
           },
           lastMessagePreview: latestMessage?.body ?? 'Conversation started',
           lastMessageAt: latestMessage?.createdAt ?? conversation.updatedAt,
+          unreadCount: unreadMessages.filter((message) =>
+            matchesAnyParticipantId(message.recipientId, participantKeys)
+          ).length,
           hasUnread: unreadMessages.some((message) =>
             matchesAnyParticipantId(message.recipientId, participantKeys)
           ),

--- a/backend/convex/messages.ts
+++ b/backend/convex/messages.ts
@@ -264,8 +264,53 @@ export const listUserConversations = query({
   args: {},
   handler: async (ctx) => {
     const participantKeys = await getParticipantKeys(ctx);
-    const allConversations = await ctx.db.query('conversations').collect();
-    const participantConversations = allConversations
+    const canonicalParticipantKeys = [
+      ...new Set(
+        participantKeys
+          .map((participantKey) => canonicalParticipantId(participantKey).trim())
+          .filter((participantKey) => participantKey.length > 0)
+      ),
+    ];
+    const indexedConversationResults = await Promise.all(
+      canonicalParticipantKeys.flatMap((participantKey) => [
+        ctx.db
+          .query('conversations')
+          .withIndex('by_buyer', (q) => q.eq('buyerId', participantKey))
+          .order('desc')
+          .collect(),
+        ctx.db
+          .query('conversations')
+          .withIndex('by_seller', (q) => q.eq('sellerId', participantKey))
+          .order('desc')
+          .collect(),
+        ctx.db
+          .query('conversations')
+          .withIndex('by_buyer', (q) =>
+            q.gte('buyerId', `${participantKey}|`).lt('buyerId', `${participantKey}|\uffff`)
+          )
+          .collect(),
+        ctx.db
+          .query('conversations')
+          .withIndex('by_seller', (q) =>
+            q.gte('sellerId', `${participantKey}|`).lt('sellerId', `${participantKey}|\uffff`)
+          )
+          .collect(),
+      ])
+    );
+
+    const dedupedConversationIds = new Set<Id<'conversations'>>();
+    for (const batch of indexedConversationResults) {
+      for (const conversation of batch) {
+        dedupedConversationIds.add(conversation._id);
+      }
+    }
+
+    const participantConversations = (
+      await Promise.all(
+        [...dedupedConversationIds].map((conversationId) => ctx.db.get(conversationId))
+      )
+    )
+      .filter((conversation): conversation is Doc<'conversations'> => conversation !== null)
       .filter(
         (conversation) =>
           matchesAnyParticipantId(conversation.buyerId, participantKeys) ||
@@ -273,62 +318,58 @@ export const listUserConversations = query({
       )
       .sort((a, b) => b.updatedAt - a.updatedAt);
 
-    // Legacy compatibility: collapse duplicate threads created with aliased participant IDs.
-    const dedupedConversationMap = new Map<string, Doc<'conversations'>>();
+    // Legacy compatibility: merge sibling threads created with aliased participant IDs.
+    const dedupedConversationMap = new Map<string, Doc<'conversations'>[]>();
     for (const conversation of participantConversations) {
       const isBuyer = matchesAnyParticipantId(conversation.buyerId, participantKeys);
       const otherUserId = isBuyer ? conversation.sellerId : conversation.buyerId;
       const dedupeKey = `${conversation.listingId}:${canonicalParticipantId(otherUserId)}`;
-      const existing = dedupedConversationMap.get(dedupeKey);
-      if (!existing || conversation.updatedAt > existing.updatedAt) {
-        dedupedConversationMap.set(dedupeKey, conversation);
-      }
-    }
-    const conversations = [...dedupedConversationMap.values()].sort(
-      (a, b) => b.updatedAt - a.updatedAt
-    );
-
-    const allProfiles = await ctx.db.query('profiles').collect();
-    const profilesByCanonicalUserId = new Map<string, Doc<'profiles'>>();
-    for (const profile of allProfiles) {
-      const canonicalUserId = canonicalParticipantId(profile.userId);
-      if (!profilesByCanonicalUserId.has(canonicalUserId)) {
-        profilesByCanonicalUserId.set(canonicalUserId, profile);
+      const siblings = dedupedConversationMap.get(dedupeKey);
+      if (siblings) {
+        siblings.push(conversation);
+      } else {
+        dedupedConversationMap.set(dedupeKey, [conversation]);
       }
     }
 
-    const userDocsByCanonicalUserId = new Map<string, Doc<'users'> | null>();
-
-    return await Promise.all(
-      conversations.map(async (conversation) => {
-        const isBuyer = matchesAnyParticipantId(conversation.buyerId, participantKeys);
-        const otherUserId = isBuyer ? conversation.sellerId : conversation.buyerId;
+    const groupedConversations = [...dedupedConversationMap.entries()]
+      .map(([dedupeKey, siblingConversations]) => {
+        const sortedSiblings = [...siblingConversations].sort((a, b) => b.updatedAt - a.updatedAt);
+        const primaryConversation = sortedSiblings[0];
+        const isBuyer = matchesAnyParticipantId(primaryConversation.buyerId, participantKeys);
+        const otherUserId = isBuyer ? primaryConversation.sellerId : primaryConversation.buyerId;
         const canonicalOtherUserId = canonicalParticipantId(otherUserId);
+        const mergedUpdatedAt = Math.max(
+          ...sortedSiblings.map((conversation) => conversation.updatedAt)
+        );
 
-        let otherUserDoc = userDocsByCanonicalUserId.get(canonicalOtherUserId);
-        if (otherUserDoc === undefined) {
-          const normalizedOtherUserId = await ctx.db.normalizeId('users', canonicalOtherUserId);
-          otherUserDoc = normalizedOtherUserId ? await ctx.db.get(normalizedOtherUserId) : null;
-          userDocsByCanonicalUserId.set(canonicalOtherUserId, otherUserDoc);
-        }
+        return {
+          dedupeKey,
+          primaryConversation,
+          siblingConversations: sortedSiblings,
+          otherUserId,
+          canonicalOtherUserId,
+          mergedUpdatedAt,
+        };
+      })
+      .sort((a, b) => b.mergedUpdatedAt - a.mergedUpdatedAt);
 
-        const [listing, latestMessage, unreadMessages] = await Promise.all([
-          ctx.db.get(conversation.listingId),
-          ctx.db
-            .query('messages')
-            .withIndex('by_conversation_createdAt', (q) => q.eq('conversationId', conversation._id))
-            .order('desc')
-            .first(),
-          ctx.db
-            .query('messages')
-            .withIndex('by_conversation_recipient_readAt', (q) =>
-              q.eq('conversationId', conversation._id)
-            )
-            .filter((q) => q.eq(q.field('readAt'), 0))
-            .collect(),
-        ]);
-        const otherProfile = profilesByCanonicalUserId.get(canonicalOtherUserId) ?? null;
+    const listingIds = [
+      ...new Set(groupedConversations.map((group) => group.primaryConversation.listingId)),
+    ];
+    const listingDocs = await Promise.all(listingIds.map((listingId) => ctx.db.get(listingId)));
+    const listingById = new Map<Id<'listings'>, Doc<'listings'> | null>();
+    for (let index = 0; index < listingIds.length; index += 1) {
+      listingById.set(listingIds[index], listingDocs[index]);
+    }
 
+    const listingSummariesById = new Map<
+      Id<'listings'>,
+      { id: Id<'listings'>; title: string; thumbnailUrl: string | null }
+    >();
+    await Promise.all(
+      listingIds.map(async (listingId) => {
+        const listing = listingById.get(listingId) ?? null;
         const thumbnailSource = listing?.images?.[0] ?? null;
         let listingThumbnailUrl: string | null = null;
         if (thumbnailSource) {
@@ -343,25 +384,154 @@ export const listUserConversations = query({
           }
         }
 
+        listingSummariesById.set(listingId, {
+          id: listingId,
+          title: listing?.title ?? 'Listing unavailable',
+          thumbnailUrl: listingThumbnailUrl,
+        });
+      })
+    );
+
+    const canonicalOtherUserIds = [
+      ...new Set(groupedConversations.map((group) => group.canonicalOtherUserId)),
+    ];
+    const [userEntries, profileEntries] = await Promise.all([
+      Promise.all(
+        canonicalOtherUserIds.map(async (canonicalOtherUserId) => {
+          const normalizedOtherUserId = await ctx.db.normalizeId('users', canonicalOtherUserId);
+          const otherUserDoc = normalizedOtherUserId
+            ? await ctx.db.get(normalizedOtherUserId)
+            : null;
+          return [canonicalOtherUserId, otherUserDoc] as const;
+        })
+      ),
+      Promise.all(
+        canonicalOtherUserIds.map(async (canonicalOtherUserId) => {
+          const [exactProfile, aliasProfile] = await Promise.all([
+            ctx.db
+              .query('profiles')
+              .withIndex('by_userId', (q) => q.eq('userId', canonicalOtherUserId))
+              .first(),
+            ctx.db
+              .query('profiles')
+              .withIndex('by_userId', (q) =>
+                q
+                  .gte('userId', `${canonicalOtherUserId}|`)
+                  .lt('userId', `${canonicalOtherUserId}|\uffff`)
+              )
+              .first(),
+          ]);
+          return [canonicalOtherUserId, exactProfile ?? aliasProfile ?? null] as const;
+        })
+      ),
+    ]);
+    const userDocsByCanonicalUserId = new Map<string, Doc<'users'> | null>(userEntries);
+    const profilesByCanonicalUserId = new Map<string, Doc<'profiles'> | null>(profileEntries);
+
+    const lastMessageIds = [
+      ...new Set(
+        groupedConversations.flatMap((group) =>
+          group.siblingConversations
+            .map((conversation) => conversation.lastMessageId)
+            .filter((lastMessageId): lastMessageId is Id<'messages'> => lastMessageId !== undefined)
+        )
+      ),
+    ];
+    const lastMessageDocs = await Promise.all(
+      lastMessageIds.map((lastMessageId) => ctx.db.get(lastMessageId))
+    );
+    const lastMessagesById = new Map<Id<'messages'>, Doc<'messages'>>();
+    for (let index = 0; index < lastMessageIds.length; index += 1) {
+      const message = lastMessageDocs[index];
+      if (message) {
+        lastMessagesById.set(lastMessageIds[index], message);
+      }
+    }
+
+    return await Promise.all(
+      groupedConversations.map(async (group) => {
+        let latestMessage: Doc<'messages'> | null = null;
+        for (const siblingConversation of group.siblingConversations) {
+          const siblingLastMessageId = siblingConversation.lastMessageId;
+          if (!siblingLastMessageId) {
+            continue;
+          }
+          const siblingLastMessage = lastMessagesById.get(siblingLastMessageId);
+          if (
+            siblingLastMessage &&
+            (!latestMessage || siblingLastMessage.createdAt > latestMessage.createdAt)
+          ) {
+            latestMessage = siblingLastMessage;
+          }
+        }
+
+        const conversationsMissingLastMessageId = group.siblingConversations.filter(
+          (siblingConversation) => !siblingConversation.lastMessageId
+        );
+        if (conversationsMissingLastMessageId.length > 0) {
+          const fallbackMessages = await Promise.all(
+            conversationsMissingLastMessageId.map((siblingConversation) =>
+              ctx.db
+                .query('messages')
+                .withIndex('by_conversation_createdAt', (q) =>
+                  q.eq('conversationId', siblingConversation._id)
+                )
+                .order('desc')
+                .first()
+            )
+          );
+          for (const fallbackMessage of fallbackMessages) {
+            if (
+              fallbackMessage &&
+              (!latestMessage || fallbackMessage.createdAt > latestMessage.createdAt)
+            ) {
+              latestMessage = fallbackMessage;
+            }
+          }
+        }
+
+        const unreadByConversation = await Promise.all(
+          group.siblingConversations.map((siblingConversation) =>
+            ctx.db
+              .query('messages')
+              .withIndex('by_conversation_recipient_readAt', (q) =>
+                q.eq('conversationId', siblingConversation._id)
+              )
+              .filter((q) => q.eq(q.field('readAt'), 0))
+              .collect()
+          )
+        );
+        const unreadCount = unreadByConversation.reduce(
+          (count, unreadMessages) =>
+            count +
+            unreadMessages.filter((message) =>
+              matchesAnyParticipantId(message.recipientId, participantKeys)
+            ).length,
+          0
+        );
+
+        const otherProfile = profilesByCanonicalUserId.get(group.canonicalOtherUserId) ?? null;
+        const otherUserDoc = userDocsByCanonicalUserId.get(group.canonicalOtherUserId) ?? null;
+
         return {
-          ...conversation,
+          ...group.primaryConversation,
+          updatedAt: group.mergedUpdatedAt,
+          mergedConversationIds: group.siblingConversations.map(
+            (siblingConversation) => siblingConversation._id
+          ),
           otherUser: {
-            id: otherUserId,
-            name: displayNameFromProfile(otherProfile, otherUserDoc, otherUserId),
+            id: group.otherUserId,
+            name: displayNameFromProfile(otherProfile, otherUserDoc, group.otherUserId),
           },
-          listing: {
-            id: conversation.listingId,
-            title: listing?.title ?? 'Listing unavailable',
-            thumbnailUrl: listingThumbnailUrl ?? null,
+          listing: listingSummariesById.get(group.primaryConversation.listingId) ?? {
+            id: group.primaryConversation.listingId,
+            title: 'Listing unavailable',
+            thumbnailUrl: null,
           },
           lastMessagePreview: latestMessage?.body ?? 'Conversation started',
-          lastMessageAt: latestMessage?.createdAt ?? conversation.updatedAt,
-          unreadCount: unreadMessages.filter((message) =>
-            matchesAnyParticipantId(message.recipientId, participantKeys)
-          ).length,
-          hasUnread: unreadMessages.some((message) =>
-            matchesAnyParticipantId(message.recipientId, participantKeys)
-          ),
+          lastMessageAt: latestMessage?.createdAt ?? group.mergedUpdatedAt,
+          unreadCount,
+          hasUnread: unreadCount > 0,
         };
       })
     );
@@ -467,9 +637,9 @@ export const markMessagesAsRead = mutation({
     const now = Date.now();
 
     if (isBuyer) {
-      await ctx.db.patch(convo._id, { buyerLastReadAt: now, updatedAt: now });
+      await ctx.db.patch(convo._id, { buyerLastReadAt: now });
     } else if (isSeller) {
-      await ctx.db.patch(convo._id, { sellerLastReadAt: now, updatedAt: now });
+      await ctx.db.patch(convo._id, { sellerLastReadAt: now });
     }
 
     const unread = await ctx.db

--- a/backend/convex/messages.ts
+++ b/backend/convex/messages.ts
@@ -26,37 +26,15 @@ function isRemoteUrl(value: string) {
   return value.startsWith('http://') || value.startsWith('https://');
 }
 
-function displayNameFromProfile(
-  profile: { name?: string; email?: string; userId?: string } | null,
-  user: { name?: string; email?: string } | null,
-  fallbackUserId: string
-) {
+function displayNameFromProfile(profile: { name?: string } | null, user: { name?: string } | null) {
   const userName = user?.name?.trim();
   if (userName && userName.length > 0) {
     return userName;
   }
 
-  if (!profile) {
-    const userEmail = user?.email?.trim().toLowerCase();
-    if (userEmail && userEmail.includes('@')) {
-      return userEmail.split('@')[0];
-    }
-
-    const normalized = fallbackUserId.trim().toLowerCase();
-    if (normalized.includes('@')) {
-      return normalized.split('@')[0];
-    }
-    return 'User';
-  }
-
-  const trimmedName = profile.name?.trim();
-  if (trimmedName && trimmedName.length > 0) {
-    return trimmedName;
-  }
-
-  const email = profile.email?.trim().toLowerCase();
-  if (email && email.includes('@')) {
-    return email.split('@')[0];
+  const profileName = profile?.name?.trim();
+  if (profileName && profileName.length > 0) {
+    return profileName;
   }
 
   return 'User';
@@ -123,8 +101,9 @@ export const sendMessage = action({
     type: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<{ messageId: Id<'messages'> }> => {
+    const trimmedBody = args.body.trim();
     // Validate message body length
-    if (args.body.length === 0) {
+    if (trimmedBody.length === 0) {
       throw new ConvexError('Message cannot be empty');
     }
     if (args.body.length > PAYLOAD_BOUNDS.MESSAGE_MAX) {
@@ -246,16 +225,11 @@ export const debugCreateConversationID = internalMutation({
 export const getConversationHistory = query({
   args: {
     conversationId: v.id('conversations'),
+    siblingConversationIds: v.optional(v.array(v.id('conversations'))),
   },
   handler: async (ctx, args) => {
-    await requireParticipant(ctx, args.conversationId);
-
-    const messages = await ctx.db
-      .query('messages')
-      .withIndex('by_conversation_createdAt', (q) => q.eq('conversationId', args.conversationId))
-      .collect();
-
-    return messages;
+    const { conversationIds } = await requireConversationScope(ctx, args);
+    return await collectMessagesForConversationScope(ctx, conversationIds);
   },
 });
 
@@ -516,12 +490,14 @@ export const listUserConversations = query({
         return {
           ...group.primaryConversation,
           updatedAt: group.mergedUpdatedAt,
-          mergedConversationIds: group.siblingConversations.map(
+          mergedConversationId: group.primaryConversation._id,
+          siblingConversationIds: group.siblingConversations.map(
             (siblingConversation) => siblingConversation._id
           ),
+          canonicalOtherUserId: group.canonicalOtherUserId,
           otherUser: {
             id: group.otherUserId,
-            name: displayNameFromProfile(otherProfile, otherUserDoc, group.otherUserId),
+            name: displayNameFromProfile(otherProfile, otherUserDoc),
           },
           listing: listingSummariesById.get(group.primaryConversation.listingId) ?? {
             id: group.primaryConversation.listingId,
@@ -538,20 +514,86 @@ export const listUserConversations = query({
   },
 });
 
-async function requireParticipant(
+async function requireConversationScope(
   ctx: MutationCtx | QueryCtx,
-  conversationId: Id<'conversations'>
+  args: {
+    conversationId: Id<'conversations'>;
+    siblingConversationIds?: Id<'conversations'>[];
+  }
 ) {
   const participantKeys = await getParticipantKeys(ctx);
-  const userId = participantKeys[0];
-  const convo = await ctx.db.get(conversationId);
-  if (!convo) throw new ConvexError('Conversation not found');
+  const scopedConversationIdSet = new Set<Id<'conversations'>>([
+    args.conversationId,
+    ...(args.siblingConversationIds ?? []),
+  ]);
+  const scopedConversationIds = [...scopedConversationIdSet];
 
-  const isBuyer = matchesAnyParticipantId(convo.buyerId, participantKeys);
-  const isSeller = matchesAnyParticipantId(convo.sellerId, participantKeys);
-  if (!isBuyer && !isSeller) throw new ConvexError('Forbidden');
+  const scopedConversations = await Promise.all(
+    scopedConversationIds.map((conversationId) => ctx.db.get(conversationId))
+  );
+  if (scopedConversations.some((conversation) => conversation === null)) {
+    throw new ConvexError('Conversation not found');
+  }
+  const conversations = scopedConversations as Doc<'conversations'>[];
+  const primaryConversation = conversations.find(
+    (conversation) => conversation._id === args.conversationId
+  );
+  if (!primaryConversation) {
+    throw new ConvexError('Conversation not found');
+  }
 
-  return { userId, participantKeys, convo, isBuyer, isSeller };
+  const getScopedConversationMeta = (conversation: Doc<'conversations'>) => {
+    const isBuyer = matchesAnyParticipantId(conversation.buyerId, participantKeys);
+    const isSeller = matchesAnyParticipantId(conversation.sellerId, participantKeys);
+    if (!isBuyer && !isSeller) {
+      throw new ConvexError('Forbidden');
+    }
+
+    const otherUserId = isBuyer ? conversation.sellerId : conversation.buyerId;
+    return {
+      conversation,
+      isBuyer,
+      isSeller,
+      dedupeKey: `${conversation.listingId}:${canonicalParticipantId(otherUserId)}`,
+    };
+  };
+
+  const primaryMeta = getScopedConversationMeta(primaryConversation);
+  const conversationScope = conversations.map((conversation) => {
+    const scopedMeta = getScopedConversationMeta(conversation);
+    if (scopedMeta.dedupeKey !== primaryMeta.dedupeKey) {
+      throw new ConvexError('Forbidden');
+    }
+    return {
+      conversation,
+      isBuyer: scopedMeta.isBuyer,
+      isSeller: scopedMeta.isSeller,
+    };
+  });
+
+  return {
+    participantKeys,
+    conversationIds: conversationScope.map(
+      (scopedConversation) => scopedConversation.conversation._id
+    ),
+    conversationScope,
+  };
+}
+
+async function collectMessagesForConversationScope(
+  ctx: MutationCtx | QueryCtx,
+  conversationIds: Id<'conversations'>[]
+) {
+  const messageBatches = await Promise.all(
+    conversationIds.map((conversationId) =>
+      ctx.db
+        .query('messages')
+        .withIndex('by_conversation_createdAt', (q) => q.eq('conversationId', conversationId))
+        .collect()
+    )
+  );
+
+  return messageBatches.flat().sort((left, right) => left.createdAt - right.createdAt);
 }
 
 export const getOrCreateConversation = mutation({
@@ -627,34 +669,47 @@ export const getOrCreateConversation = mutation({
 export const markMessagesAsRead = mutation({
   args: {
     conversationId: v.id('conversations'),
+    siblingConversationIds: v.optional(v.array(v.id('conversations'))),
   },
   handler: async (ctx, args) => {
-    const { convo, participantKeys, isBuyer, isSeller } = await requireParticipant(
-      ctx,
-      args.conversationId
-    );
+    const { conversationScope, participantKeys } = await requireConversationScope(ctx, args);
 
     const now = Date.now();
 
-    if (isBuyer) {
-      await ctx.db.patch(convo._id, { buyerLastReadAt: now });
-    } else if (isSeller) {
-      await ctx.db.patch(convo._id, { sellerLastReadAt: now });
-    }
+    await Promise.all(
+      conversationScope.map(async ({ conversation, isBuyer, isSeller }) => {
+        if (isBuyer) {
+          await ctx.db.patch(conversation._id, { buyerLastReadAt: now });
+        } else if (isSeller) {
+          await ctx.db.patch(conversation._id, { sellerLastReadAt: now });
+        }
+      })
+    );
 
-    const unread = await ctx.db
-      .query('messages')
-      .withIndex('by_conversation_recipient_readAt', (q) =>
-        q.eq('conversationId', args.conversationId)
+    const unreadMessagesByScope = await Promise.all(
+      conversationScope.flatMap(({ conversation }) =>
+        participantKeys.map((participantKey) =>
+          ctx.db
+            .query('messages')
+            .withIndex('by_conversation_recipient_readAt', (q) =>
+              q
+                .eq('conversationId', conversation._id)
+                .eq('recipientId', participantKey)
+                .eq('readAt', 0)
+            )
+            .collect()
+        )
       )
-      .filter((q) => q.eq(q.field('readAt'), 0))
-      .collect();
-
-    for (const msg of unread) {
-      if (matchesAnyParticipantId(msg.recipientId, participantKeys)) {
-        await ctx.db.patch(msg._id, { readAt: now });
+    );
+    const unreadMessageIds = new Set<Id<'messages'>>();
+    for (const unreadBatch of unreadMessagesByScope) {
+      for (const message of unreadBatch) {
+        unreadMessageIds.add(message._id);
       }
     }
+    await Promise.all(
+      [...unreadMessageIds].map((messageId) => ctx.db.patch(messageId, { readAt: now }))
+    );
 
     return { ok: true };
   },
@@ -691,13 +746,10 @@ export const backfillMessagingFields = internalMutation({
 export const messagesByConversation = query({
   args: {
     conversationId: v.id('conversations'),
+    siblingConversationIds: v.optional(v.array(v.id('conversations'))),
   },
   handler: async (ctx, args) => {
-    await requireParticipant(ctx, args.conversationId);
-
-    return await ctx.db
-      .query('messages')
-      .withIndex('by_conversation_createdAt', (q) => q.eq('conversationId', args.conversationId))
-      .collect();
+    const { conversationIds } = await requireConversationScope(ctx, args);
+    return await collectMessagesForConversationScope(ctx, conversationIds);
   },
 });

--- a/backend/convex/messages.ts
+++ b/backend/convex/messages.ts
@@ -8,6 +8,35 @@ export const PAYLOAD_BOUNDS = {
   MESSAGE_MAX: 2000,
 };
 
+function isRemoteUrl(value: string) {
+  return value.startsWith('http://') || value.startsWith('https://');
+}
+
+function displayNameFromProfile(
+  profile: { name?: string; email?: string; userId?: string } | null,
+  fallbackUserId: string
+) {
+  if (!profile) {
+    const normalized = fallbackUserId.trim().toLowerCase();
+    if (normalized.includes('@')) {
+      return normalized.split('@')[0];
+    }
+    return 'User';
+  }
+
+  const trimmedName = profile.name?.trim();
+  if (trimmedName && trimmedName.length > 0) {
+    return trimmedName;
+  }
+
+  const email = profile.email?.trim().toLowerCase();
+  if (email && email.includes('@')) {
+    return email.split('@')[0];
+  }
+
+  return 'User';
+}
+
 // Internal query: get conversation and verify user is a participant (used by sendMessage action)
 export const internalGetConversation = internalQuery({
   args: { conversationId: v.id('conversations') },
@@ -203,7 +232,65 @@ export const listUserConversations = query({
       .order('desc')
       .collect();
 
-    return [...buyerConvos, ...sellerConvos].sort((a, b) => b.updatedAt - a.updatedAt);
+    const conversations = [...buyerConvos, ...sellerConvos].sort(
+      (a, b) => b.updatedAt - a.updatedAt
+    );
+
+    return await Promise.all(
+      conversations.map(async (conversation) => {
+        const otherUserId =
+          conversation.buyerId === userId ? conversation.sellerId : conversation.buyerId;
+
+        const [otherProfile, listing, unreadMessage, latestMessage] = await Promise.all([
+          ctx.db
+            .query('profiles')
+            .withIndex('by_userId', (q) => q.eq('userId', otherUserId))
+            .first(),
+          ctx.db.get(conversation.listingId),
+          ctx.db
+            .query('messages')
+            .withIndex('by_conversation_recipient_readAt', (q) =>
+              q.eq('conversationId', conversation._id).eq('recipientId', userId).eq('readAt', 0)
+            )
+            .first(),
+          ctx.db
+            .query('messages')
+            .withIndex('by_conversation_createdAt', (q) => q.eq('conversationId', conversation._id))
+            .order('desc')
+            .first(),
+        ]);
+
+        const thumbnailSource = listing?.images?.[0] ?? null;
+        let listingThumbnailUrl: string | null = null;
+        if (thumbnailSource) {
+          if (isRemoteUrl(thumbnailSource)) {
+            listingThumbnailUrl = thumbnailSource;
+          } else {
+            try {
+              listingThumbnailUrl = await ctx.storage.getUrl(thumbnailSource as Id<'_storage'>);
+            } catch {
+              listingThumbnailUrl = null;
+            }
+          }
+        }
+
+        return {
+          ...conversation,
+          otherUser: {
+            id: otherUserId,
+            name: displayNameFromProfile(otherProfile, otherUserId),
+          },
+          listing: {
+            id: conversation.listingId,
+            title: listing?.title ?? 'Listing unavailable',
+            thumbnailUrl: listingThumbnailUrl ?? null,
+          },
+          lastMessagePreview: latestMessage?.body ?? 'Conversation started',
+          lastMessageAt: latestMessage?.createdAt ?? conversation.updatedAt,
+          hasUnread: unreadMessage !== null,
+        };
+      })
+    );
   },
 });
 

--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -48,7 +48,7 @@ function WebTabsHeaderLayout({ unreadCount }: { unreadCount: number }) {
 
               const isInboxTab = tab.href === '/inbox';
               const showUnreadBadge = isInboxTab && unreadCount > 0;
-              const formattedUnreadCount = unreadCount > 99 ? '99+' : String(unreadCount);
+              const formattedUnreadCount = unreadCount > 9 ? '9+' : String(unreadCount);
 
               return (
                 <Link key={tab.href} href={tab.href as never} asChild>
@@ -79,8 +79,11 @@ export default function TabsLayout() {
   const { isAuthenticated } = useAuth();
   const conversations = useQuery(api.messages.listUserConversations, isAuthenticated ? {} : 'skip');
   const unreadCount =
-    conversations?.reduce((count, conversation) => count + (conversation.hasUnread ? 1 : 0), 0) ??
-    0;
+    conversations?.reduce(
+      (count, conversation) =>
+        count + (conversation.unreadCount ?? (conversation.hasUnread ? 1 : 0)),
+      0
+    ) ?? 0;
 
   if (Platform.OS === 'web') {
     return <WebTabsHeaderLayout unreadCount={unreadCount} />;
@@ -130,7 +133,7 @@ export default function TabsLayout() {
         />
         {unreadCount > 0 ? (
           <NativeTabs.Trigger.Badge>
-            {unreadCount > 99 ? '99+' : String(unreadCount)}
+            {unreadCount > 9 ? '9+' : String(unreadCount)}
           </NativeTabs.Trigger.Badge>
         ) : null}
       </NativeTabs.Trigger>

--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -1,6 +1,9 @@
 import { Link, Slot, usePathname } from 'expo-router';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
+import { useQuery } from 'convex/react';
+import { api } from 'convex/_generated/api';
 import { Platform, Pressable, StyleSheet, Text, useColorScheme, View } from 'react-native';
+import { useAuth } from '../../hooks/useAuth';
 
 type WebTab = {
   href: '/' | '/search' | '/my-listings' | '/inbox' | '/settings';
@@ -23,7 +26,7 @@ function isTabActive(pathname: string, href: WebTab['href']) {
   return pathname === href || pathname.startsWith(`${href}/`);
 }
 
-function WebTabsHeaderLayout() {
+function WebTabsHeaderLayout({ unreadCount }: { unreadCount: number }) {
   const pathname = usePathname();
 
   return (
@@ -43,10 +46,21 @@ function WebTabsHeaderLayout() {
                 active && styles.webTabLabelActive,
               ]);
 
+              const isInboxTab = tab.href === '/inbox';
+              const showUnreadBadge = isInboxTab && unreadCount > 0;
+              const formattedUnreadCount = unreadCount > 99 ? '99+' : String(unreadCount);
+
               return (
                 <Link key={tab.href} href={tab.href as never} asChild>
                   <Pressable style={tabButtonStyle}>
-                    <Text style={tabLabelStyle}>{tab.label}</Text>
+                    <View style={styles.webTabInner}>
+                      <Text style={tabLabelStyle}>{tab.label}</Text>
+                      {showUnreadBadge ? (
+                        <View style={styles.webUnreadBadge}>
+                          <Text style={styles.webUnreadBadgeText}>{formattedUnreadCount}</Text>
+                        </View>
+                      ) : null}
+                    </View>
                   </Pressable>
                 </Link>
               );
@@ -62,9 +76,14 @@ function WebTabsHeaderLayout() {
 
 export default function TabsLayout() {
   const colorScheme = useColorScheme();
+  const { isAuthenticated } = useAuth();
+  const conversations = useQuery(api.messages.listUserConversations, isAuthenticated ? {} : 'skip');
+  const unreadCount =
+    conversations?.reduce((count, conversation) => count + (conversation.hasUnread ? 1 : 0), 0) ??
+    0;
 
   if (Platform.OS === 'web') {
-    return <WebTabsHeaderLayout />;
+    return <WebTabsHeaderLayout unreadCount={unreadCount} />;
   }
 
   const isDarkMode = colorScheme === 'dark';
@@ -109,6 +128,11 @@ export default function TabsLayout() {
           sf={{ default: 'bubble.left', selected: 'bubble.left.fill' }}
           md="chat"
         />
+        {unreadCount > 0 ? (
+          <NativeTabs.Trigger.Badge>
+            {unreadCount > 99 ? '99+' : String(unreadCount)}
+          </NativeTabs.Trigger.Badge>
+        ) : null}
       </NativeTabs.Trigger>
       <NativeTabs.Trigger name="settings" disableTransparentOnScrollEdge>
         {/* NativeTabs expects plain text inside Trigger.Label. */}
@@ -164,6 +188,11 @@ const styles = StyleSheet.create({
     paddingHorizontal: 14,
     paddingVertical: 8,
   },
+  webTabInner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
   webTabButtonActive: {
     backgroundColor: '#154734',
   },
@@ -174,6 +203,21 @@ const styles = StyleSheet.create({
   },
   webTabLabelActive: {
     color: '#fff',
+  },
+  webUnreadBadge: {
+    minWidth: 18,
+    height: 18,
+    borderRadius: 999,
+    paddingHorizontal: 5,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#d93025',
+  },
+  webUnreadBadgeText: {
+    color: '#fff',
+    fontSize: 11,
+    fontWeight: '700',
+    fontVariant: ['tabular-nums'],
   },
   headerSpacer: {
     width: 84,

--- a/frontend/app/(tabs)/inbox.tsx
+++ b/frontend/app/(tabs)/inbox.tsx
@@ -12,8 +12,91 @@ import {
 import { useRouter } from 'expo-router';
 import { useQuery } from 'convex/react';
 import { api } from 'convex/_generated/api';
+import { Id } from 'convex/_generated/dataModel';
 import { useEntranceAnimation } from '../../hooks/useEntranceAnimation';
 import { useAuth } from '../../hooks/useAuth';
+import { useResolvedImageUrls } from '../../hooks/useResolvedImageUrls';
+
+type ConversationRowItem = {
+  _id: string;
+  listingId?: Id<'listings'>;
+  updatedAt?: number;
+  hasUnread?: boolean;
+  lastMessagePreview?: string;
+  lastMessageAt?: number;
+  otherUser?: {
+    name?: string;
+  };
+  listing?: {
+    id?: Id<'listings'>;
+    title?: string;
+    thumbnailUrl?: string | null;
+  };
+};
+
+function ConversationRow({
+  item,
+  index,
+  entranceStyle,
+  onPress,
+  formatTimestamp,
+}: {
+  item: ConversationRowItem;
+  index: number;
+  entranceStyle: object;
+  onPress: () => void;
+  formatTimestamp: (timestamp: number) => string;
+}) {
+  const hasUnread = Boolean(item.hasUnread);
+  const otherUserName = item.otherUser?.name ?? 'User';
+
+  const listingId = (item.listing?.id ?? item.listingId ?? null) as Id<'listings'> | null;
+  const listing = useQuery(api.listings.getListing, listingId ? { id: listingId } : 'skip');
+
+  const listingTitle = item.listing?.title ?? listing?.title ?? 'Listing unavailable';
+  const thumbnailSource =
+    item.listing?.thumbnailUrl ??
+    (listing?.images && listing.images.length > 0 ? listing.images[0] : null);
+  const { mappedUrls } = useResolvedImageUrls(thumbnailSource ? [thumbnailSource] : []);
+  const thumbnailUrl = mappedUrls[0] ?? null;
+
+  const lastMessagePreview = item.lastMessagePreview ?? 'Conversation started';
+  const lastMessageAt = item.lastMessageAt ?? item.updatedAt ?? Date.now();
+
+  return (
+    <Animated.View style={index === 0 ? entranceStyle : null}>
+      <Pressable
+        style={({ pressed }) => [styles.row, pressed && styles.buttonPressed]}
+        onPress={onPress}
+      >
+        {thumbnailUrl ? (
+          <Image source={{ uri: thumbnailUrl }} style={styles.thumbnail} />
+        ) : (
+          <View style={[styles.thumbnail, styles.thumbnailPlaceholder]}>
+            <Text style={styles.thumbnailPlaceholderText}>No Image</Text>
+          </View>
+        )}
+        <View style={styles.rowBody}>
+          <View style={styles.rowTop}>
+            <Text style={[styles.otherUserName, hasUnread && styles.unreadText]} numberOfLines={1}>
+              {otherUserName}
+            </Text>
+            <Text style={styles.timestamp}>{formatTimestamp(lastMessageAt)}</Text>
+          </View>
+          <Text style={styles.listingTitle} numberOfLines={1}>
+            {listingTitle}
+          </Text>
+          <View style={styles.previewRow}>
+            <Text style={[styles.messagePreview, hasUnread && styles.unreadText]} numberOfLines={1}>
+              {lastMessagePreview}
+            </Text>
+            {hasUnread && <View style={styles.unreadDot} />}
+          </View>
+        </View>
+      </Pressable>
+    </Animated.View>
+  );
+}
 
 export default function InboxScreen() {
   const router = useRouter();
@@ -110,48 +193,18 @@ export default function InboxScreen() {
       }
       renderItem={({ item, index }) => {
         return (
-          <Animated.View style={index === 0 ? entranceStyle : null}>
-            <Pressable
-              style={({ pressed }) => [styles.row, pressed && styles.buttonPressed]}
-              onPress={() =>
-                router.push({
-                  pathname: '/conversations/[id]',
-                  params: { id: String(item._id) },
-                } as never)
-              }
-            >
-              {item.listing.thumbnailUrl ? (
-                <Image source={{ uri: item.listing.thumbnailUrl }} style={styles.thumbnail} />
-              ) : (
-                <View style={[styles.thumbnail, styles.thumbnailPlaceholder]}>
-                  <Text style={styles.thumbnailPlaceholderText}>No Image</Text>
-                </View>
-              )}
-              <View style={styles.rowBody}>
-                <View style={styles.rowTop}>
-                  <Text
-                    style={[styles.otherUserName, item.hasUnread && styles.unreadText]}
-                    numberOfLines={1}
-                  >
-                    {item.otherUser.name}
-                  </Text>
-                  <Text style={styles.timestamp}>{formatTimestamp(item.lastMessageAt)}</Text>
-                </View>
-                <Text style={styles.listingTitle} numberOfLines={1}>
-                  {item.listing.title}
-                </Text>
-                <View style={styles.previewRow}>
-                  <Text
-                    style={[styles.messagePreview, item.hasUnread && styles.unreadText]}
-                    numberOfLines={1}
-                  >
-                    {item.lastMessagePreview}
-                  </Text>
-                  {item.hasUnread && <View style={styles.unreadDot} />}
-                </View>
-              </View>
-            </Pressable>
-          </Animated.View>
+          <ConversationRow
+            item={item as ConversationRowItem}
+            index={index}
+            entranceStyle={entranceStyle}
+            formatTimestamp={formatTimestamp}
+            onPress={() =>
+              router.push({
+                pathname: '/conversations/[id]',
+                params: { id: String(item._id) },
+              } as never)
+            }
+          />
         );
       }}
       ItemSeparatorComponent={() => <View style={styles.separator} />}

--- a/frontend/app/(tabs)/inbox.tsx
+++ b/frontend/app/(tabs)/inbox.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import {
   ActivityIndicator,
   Animated,
@@ -31,6 +31,10 @@ type ConversationRowItem = {
     thumbnailUrl?: string | null;
   };
 };
+
+function ItemSeparator() {
+  return <View style={styles.separator} />;
+}
 
 function ConversationRow({
   item,
@@ -120,21 +124,24 @@ export default function InboxScreen() {
     []
   );
 
-  const formatTimestamp = (timestamp: number) => {
-    const value = new Date(timestamp);
-    const now = new Date();
-    const sameDay = value.toDateString() === now.toDateString();
-    if (sameDay) {
-      return formatter.format(value);
-    }
+  const formatTimestamp = useCallback(
+    (timestamp: number) => {
+      const value = new Date(timestamp);
+      const now = new Date();
+      const sameDay = value.toDateString() === now.toDateString();
+      if (sameDay) {
+        return formatter.format(value);
+      }
 
-    const diff = now.getTime() - value.getTime();
-    if (diff < 1000 * 60 * 60 * 24 * 7) {
-      return weekdayFormatter.format(value);
-    }
+      const diff = now.getTime() - value.getTime();
+      if (diff < 1000 * 60 * 60 * 24 * 7) {
+        return weekdayFormatter.format(value);
+      }
 
-    return shortDateFormatter.format(value);
-  };
+      return shortDateFormatter.format(value);
+    },
+    [formatter, weekdayFormatter, shortDateFormatter]
+  );
 
   if (authLoading) {
     return (
@@ -197,7 +204,7 @@ export default function InboxScreen() {
           />
         );
       }}
-      ItemSeparatorComponent={() => <View style={styles.separator} />}
+      ItemSeparatorComponent={ItemSeparator}
     />
   );
 }

--- a/frontend/app/(tabs)/inbox.tsx
+++ b/frontend/app/(tabs)/inbox.tsx
@@ -1,24 +1,161 @@
-import { Animated, ScrollView, StyleSheet, Text } from 'react-native';
+import { useMemo } from 'react';
+import {
+  ActivityIndicator,
+  Animated,
+  FlatList,
+  Image,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { useQuery } from 'convex/react';
+import { api } from 'convex/_generated/api';
 import { useEntranceAnimation } from '../../hooks/useEntranceAnimation';
+import { useAuth } from '../../hooks/useAuth';
 
 export default function InboxScreen() {
+  const router = useRouter();
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
   const entranceStyle = useEntranceAnimation();
+  const conversations = useQuery(api.messages.listUserConversations, isAuthenticated ? {} : 'skip');
+
+  const formatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(undefined, {
+        hour: 'numeric',
+        minute: '2-digit',
+      }),
+    []
+  );
+
+  const shortDateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(undefined, {
+        month: 'short',
+        day: 'numeric',
+      }),
+    []
+  );
+
+  const weekdayFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(undefined, {
+        weekday: 'short',
+      }),
+    []
+  );
+
+  const formatTimestamp = (timestamp: number) => {
+    const value = new Date(timestamp);
+    const now = new Date();
+    const sameDay = value.toDateString() === now.toDateString();
+    if (sameDay) {
+      return formatter.format(value);
+    }
+
+    const diff = now.getTime() - value.getTime();
+    if (diff < 1000 * 60 * 60 * 24 * 7) {
+      return weekdayFormatter.format(value);
+    }
+
+    return shortDateFormatter.format(value);
+  };
+
+  if (authLoading) {
+    return (
+      <View style={styles.centeredState}>
+        <ActivityIndicator size="small" color="#154734" />
+        <Text style={styles.stateText}>Loading inbox...</Text>
+      </View>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <View style={styles.centeredState}>
+        <Text style={styles.stateTitle}>Sign in to view your inbox</Text>
+        <Pressable
+          style={({ pressed }) => [styles.signInButton, pressed && styles.buttonPressed]}
+          onPress={() => router.push('/auth/login?returnTo=%2Finbox' as never)}
+        >
+          <Text style={styles.signInButtonText}>Sign In</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (conversations === undefined) {
+    return (
+      <View style={styles.centeredState}>
+        <ActivityIndicator size="small" color="#154734" />
+        <Text style={styles.stateText}>Loading conversations...</Text>
+      </View>
+    );
+  }
 
   return (
-    <ScrollView
+    <FlatList
+      data={conversations}
+      keyExtractor={(item) => item._id}
       style={styles.container}
       contentInsetAdjustmentBehavior="automatic"
       contentContainerStyle={styles.content}
-    >
-      <Animated.View style={[styles.card, entranceStyle]}>
-        <Text style={styles.eyebrow}>Inbox</Text>
-        <Text style={styles.title}>Messaging is coming soon</Text>
-        <Text style={styles.body}>
-          The messaging UI is being built right now. This tab is ready and will connect to live
-          conversations once that work lands.
-        </Text>
-      </Animated.View>
-    </ScrollView>
+      ListEmptyComponent={
+        <Animated.View style={[styles.card, entranceStyle]}>
+          <Text style={styles.emptyTitle}>No conversations yet</Text>
+          <Text style={styles.emptyBody}>Start by messaging a seller from any listing page.</Text>
+        </Animated.View>
+      }
+      renderItem={({ item, index }) => {
+        return (
+          <Animated.View style={index === 0 ? entranceStyle : null}>
+            <Pressable
+              style={({ pressed }) => [styles.row, pressed && styles.buttonPressed]}
+              onPress={() =>
+                router.push({
+                  pathname: '/messages/[id]',
+                  params: { id: String(item._id) },
+                } as never)
+              }
+            >
+              {item.listing.thumbnailUrl ? (
+                <Image source={{ uri: item.listing.thumbnailUrl }} style={styles.thumbnail} />
+              ) : (
+                <View style={[styles.thumbnail, styles.thumbnailPlaceholder]}>
+                  <Text style={styles.thumbnailPlaceholderText}>No Image</Text>
+                </View>
+              )}
+              <View style={styles.rowBody}>
+                <View style={styles.rowTop}>
+                  <Text
+                    style={[styles.otherUserName, item.hasUnread && styles.unreadText]}
+                    numberOfLines={1}
+                  >
+                    {item.otherUser.name}
+                  </Text>
+                  <Text style={styles.timestamp}>{formatTimestamp(item.lastMessageAt)}</Text>
+                </View>
+                <Text style={styles.listingTitle} numberOfLines={1}>
+                  {item.listing.title}
+                </Text>
+                <View style={styles.previewRow}>
+                  <Text
+                    style={[styles.messagePreview, item.hasUnread && styles.unreadText]}
+                    numberOfLines={1}
+                  >
+                    {item.lastMessagePreview}
+                  </Text>
+                  {item.hasUnread && <View style={styles.unreadDot} />}
+                </View>
+              </View>
+            </Pressable>
+          </Animated.View>
+        );
+      }}
+      ItemSeparatorComponent={() => <View style={styles.separator} />}
+    />
   );
 }
 
@@ -27,6 +164,36 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#f3f7f5',
   },
+  centeredState: {
+    flex: 1,
+    backgroundColor: '#f3f7f5',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 10,
+    paddingHorizontal: 20,
+  },
+  stateTitle: {
+    fontSize: 20,
+    color: '#0f2b21',
+    fontWeight: '700',
+    textAlign: 'center',
+  },
+  stateText: {
+    fontSize: 15,
+    color: '#5a6f65',
+  },
+  signInButton: {
+    marginTop: 8,
+    backgroundColor: '#154734',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  signInButtonText: {
+    color: '#fff',
+    fontWeight: '600',
+    fontSize: 15,
+  },
   content: {
     width: '100%',
     maxWidth: 980,
@@ -34,6 +201,84 @@ const styles = StyleSheet.create({
     paddingHorizontal: 14,
     paddingTop: 16,
     paddingBottom: 26,
+    gap: 10,
+  },
+  row: {
+    backgroundColor: '#ffffff',
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: '#d8e6df',
+    padding: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    shadowColor: '#0f172a',
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.05,
+    shadowRadius: 10,
+    elevation: 2,
+  },
+  thumbnail: {
+    width: 64,
+    height: 64,
+    borderRadius: 10,
+    backgroundColor: '#eef2ef',
+  },
+  thumbnailPlaceholder: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  thumbnailPlaceholderText: {
+    fontSize: 10,
+    color: '#7d8f85',
+    textTransform: 'uppercase',
+    fontWeight: '600',
+  },
+  rowBody: {
+    flex: 1,
+    gap: 4,
+  },
+  rowTop: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 10,
+  },
+  otherUserName: {
+    flex: 1,
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#0f2b21',
+  },
+  timestamp: {
+    fontSize: 12,
+    color: '#6b7f75',
+    fontVariant: ['tabular-nums'],
+  },
+  listingTitle: {
+    fontSize: 13,
+    color: '#4d6358',
+    fontWeight: '500',
+  },
+  previewRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  messagePreview: {
+    flex: 1,
+    fontSize: 15,
+    color: '#5a6f65',
+  },
+  unreadText: {
+    fontWeight: '700',
+    color: '#0f2b21',
+  },
+  unreadDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#154734',
   },
   card: {
     borderRadius: 20,
@@ -42,27 +287,25 @@ const styles = StyleSheet.create({
     backgroundColor: '#ffffff',
     padding: 18,
     gap: 8,
-    shadowColor: '#0f172a',
-    shadowOffset: { width: 0, height: 8 },
-    shadowOpacity: 0.08,
-    shadowRadius: 18,
-    elevation: 2,
+    alignItems: 'center',
   },
-  eyebrow: {
-    fontSize: 12,
-    color: '#2a6f52',
-    letterSpacing: 0.4,
-    fontWeight: '600',
-    textTransform: 'uppercase',
-  },
-  title: {
-    fontSize: 26,
+  emptyTitle: {
+    fontSize: 22,
     fontWeight: '700',
     color: '#0f2b21',
+    textAlign: 'center',
   },
-  body: {
+  emptyBody: {
     fontSize: 15,
     lineHeight: 22,
     color: '#5a6f65',
+    textAlign: 'center',
+  },
+  separator: {
+    height: 10,
+  },
+  buttonPressed: {
+    opacity: 0.92,
+    transform: [{ scale: 0.99 }],
   },
 });

--- a/frontend/app/(tabs)/inbox.tsx
+++ b/frontend/app/(tabs)/inbox.tsx
@@ -15,11 +15,9 @@ import { api } from 'convex/_generated/api';
 import { Id } from 'convex/_generated/dataModel';
 import { useEntranceAnimation } from '../../hooks/useEntranceAnimation';
 import { useAuth } from '../../hooks/useAuth';
-import { useResolvedImageUrls } from '../../hooks/useResolvedImageUrls';
 
 type ConversationRowItem = {
   _id: string;
-  listingId?: Id<'listings'>;
   updatedAt?: number;
   hasUnread?: boolean;
   lastMessagePreview?: string;
@@ -49,16 +47,8 @@ function ConversationRow({
 }) {
   const hasUnread = Boolean(item.hasUnread);
   const otherUserName = item.otherUser?.name ?? 'User';
-
-  const listingId = (item.listing?.id ?? item.listingId ?? null) as Id<'listings'> | null;
-  const listing = useQuery(api.listings.getListing, listingId ? { id: listingId } : 'skip');
-
-  const listingTitle = item.listing?.title ?? listing?.title ?? 'Listing unavailable';
-  const thumbnailSource =
-    item.listing?.thumbnailUrl ??
-    (listing?.images && listing.images.length > 0 ? listing.images[0] : null);
-  const { mappedUrls } = useResolvedImageUrls(thumbnailSource ? [thumbnailSource] : []);
-  const thumbnailUrl = mappedUrls[0] ?? null;
+  const listingTitle = item.listing?.title ?? 'Listing unavailable';
+  const thumbnail = item.listing?.thumbnailUrl ?? null;
 
   const lastMessagePreview = item.lastMessagePreview ?? 'Conversation started';
   const lastMessageAt = item.lastMessageAt ?? item.updatedAt ?? Date.now();
@@ -69,8 +59,8 @@ function ConversationRow({
         style={({ pressed }) => [styles.row, pressed && styles.buttonPressed]}
         onPress={onPress}
       >
-        {thumbnailUrl ? (
-          <Image source={{ uri: thumbnailUrl }} style={styles.thumbnail} />
+        {thumbnail ? (
+          <Image source={{ uri: thumbnail }} style={styles.thumbnail} />
         ) : (
           <View style={[styles.thumbnail, styles.thumbnailPlaceholder]}>
             <Text style={styles.thumbnailPlaceholderText}>No Image</Text>

--- a/frontend/app/(tabs)/inbox.tsx
+++ b/frontend/app/(tabs)/inbox.tsx
@@ -115,7 +115,7 @@ export default function InboxScreen() {
               style={({ pressed }) => [styles.row, pressed && styles.buttonPressed]}
               onPress={() =>
                 router.push({
-                  pathname: '/messages/[id]',
+                  pathname: '/conversations/[id]',
                   params: { id: String(item._id) },
                 } as never)
               }

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -56,6 +56,10 @@ export default function RootLayout() {
             name="messages/[id]"
             options={{ title: 'Messages', headerBackTitle: 'Back' }}
           />
+          <Stack.Screen
+            name="conversations/[id]"
+            options={{ title: 'Conversation', headerBackTitle: 'Inbox' }}
+          />
           <Stack.Screen name="auth/login" options={{ title: 'Sign In', headerShown: false }} />
           <Stack.Screen name="l/[id]" options={{ headerShown: false }} />
         </Stack>

--- a/frontend/app/conversations/[id].tsx
+++ b/frontend/app/conversations/[id].tsx
@@ -34,7 +34,7 @@ export default function ConversationDetailScreen() {
     typeof id === 'string' && id.trim().length > 0 ? (id as ConversationId) : null;
 
   const router = useRouter();
-  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth();
   const sendMessage = useAction(api.messages.sendMessage);
   const markMessagesAsRead = useMutation(api.messages.markMessagesAsRead);
 
@@ -236,7 +236,7 @@ export default function ConversationDetailScreen() {
         contentContainerStyle={styles.messagesContent}
         keyboardShouldPersistTaps="handled"
         renderItem={({ item }) => {
-          const isSent = item.senderId === currentUserSubject;
+          const isSent = item.senderId === currentUserSubject || item.senderId === user?._id;
           return (
             <View
               style={[

--- a/frontend/app/conversations/[id].tsx
+++ b/frontend/app/conversations/[id].tsx
@@ -72,6 +72,19 @@ export default function ConversationDetailScreen() {
     }
     return conversationList.find((item) => item._id === conversationId) ?? null;
   }, [conversationId, conversationList]);
+  const siblingConversationIds = useMemo(() => {
+    if (!conversationId || !conversation) {
+      return null;
+    }
+
+    const siblingIds = Array.isArray(conversation.siblingConversationIds)
+      ? conversation.siblingConversationIds.filter(
+          (value): value is ConversationId => typeof value === 'string' && value.length > 0
+        )
+      : [];
+
+    return [...new Set([conversationId, ...siblingIds])] as ConversationId[];
+  }, [conversation, conversationId]);
 
   const listingId = (conversation?.listing?.id ??
     conversation?.listingId ??
@@ -91,7 +104,15 @@ export default function ConversationDetailScreen() {
 
   const messages = useQuery(
     api.messages.messagesByConversation,
-    isAuthenticated && conversationId && conversation ? { conversationId } : 'skip'
+    isAuthenticated && conversationId && conversation
+      ? {
+          conversationId,
+          siblingConversationIds:
+            siblingConversationIds && siblingConversationIds.length > 1
+              ? siblingConversationIds
+              : undefined,
+        }
+      : 'skip'
   );
   const participantKeys = useMemo(
     () =>
@@ -134,7 +155,12 @@ export default function ConversationDetailScreen() {
   }, [messages]);
 
   useEffect(() => {
-    if (!conversationId || !isAuthenticated || unreadIncomingCount === 0) {
+    if (
+      !conversationId ||
+      !isAuthenticated ||
+      unreadIncomingCount === 0 ||
+      !siblingConversationIds
+    ) {
       return;
     }
 
@@ -143,14 +169,24 @@ export default function ConversationDetailScreen() {
     }
     isMarkingReadRef.current = true;
 
-    void markMessagesAsRead({ conversationId })
+    void markMessagesAsRead({
+      conversationId,
+      siblingConversationIds:
+        siblingConversationIds.length > 1 ? siblingConversationIds : undefined,
+    })
       .catch(() => {
         // Non-fatal: message stream still renders in real time.
       })
       .finally(() => {
         isMarkingReadRef.current = false;
       });
-  }, [conversationId, isAuthenticated, markMessagesAsRead, unreadIncomingCount]);
+  }, [
+    conversationId,
+    isAuthenticated,
+    markMessagesAsRead,
+    siblingConversationIds,
+    unreadIncomingCount,
+  ]);
 
   const onSend = async () => {
     const trimmed = messageBody.trim();

--- a/frontend/app/conversations/[id].tsx
+++ b/frontend/app/conversations/[id].tsx
@@ -1,0 +1,467 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  Image,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { useAction, useMutation, useQuery } from 'convex/react';
+import { api } from 'convex/_generated/api';
+import { Id } from 'convex/_generated/dataModel';
+import { useAuth } from '../../hooks/useAuth';
+
+type ConversationId = Id<'conversations'>;
+
+function formatMessageTimestamp(timestamp: number) {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(timestamp));
+}
+
+export default function ConversationDetailScreen() {
+  const { id } = useLocalSearchParams<{ id?: string | string[] }>();
+  const conversationId =
+    typeof id === 'string' && id.trim().length > 0 ? (id as ConversationId) : null;
+
+  const router = useRouter();
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const sendMessage = useAction(api.messages.sendMessage);
+  const markMessagesAsRead = useMutation(api.messages.markMessagesAsRead);
+
+  const [messageBody, setMessageBody] = useState('');
+  const [isSending, setIsSending] = useState(false);
+  const listRef = useRef<FlatList>(null);
+  const previousMessageCount = useRef(0);
+
+  const currentUserSubject = useQuery(
+    api.listings.getCurrentUserSubject,
+    isAuthenticated ? {} : 'skip'
+  );
+  const conversationList = useQuery(
+    api.messages.listUserConversations,
+    isAuthenticated ? {} : 'skip'
+  );
+
+  const conversation = useMemo(() => {
+    if (!conversationId || !conversationList) {
+      return null;
+    }
+    return conversationList.find((item) => item._id === conversationId) ?? null;
+  }, [conversationId, conversationList]);
+
+  const messages = useQuery(
+    api.messages.messagesByConversation,
+    isAuthenticated && conversationId && conversation ? { conversationId } : 'skip'
+  );
+
+  const scrollToBottom = (animated: boolean) => {
+    requestAnimationFrame(() => {
+      listRef.current?.scrollToEnd({ animated });
+    });
+  };
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      const returnTo = conversationId ? `/conversations/${conversationId}` : '/inbox';
+      router.replace(`/auth/login?returnTo=${encodeURIComponent(returnTo)}` as never);
+    }
+  }, [authLoading, conversationId, isAuthenticated, router]);
+
+  useEffect(() => {
+    if (!messages) {
+      return;
+    }
+
+    if (messages.length > 0 && previousMessageCount.current === 0) {
+      scrollToBottom(false);
+    } else if (messages.length > previousMessageCount.current) {
+      scrollToBottom(true);
+    }
+
+    previousMessageCount.current = messages.length;
+  }, [messages]);
+
+  useEffect(() => {
+    if (!conversationId || !conversation?.hasUnread) {
+      return;
+    }
+
+    void markMessagesAsRead({ conversationId }).catch(() => {
+      // Non-fatal: message stream still renders in real time.
+    });
+  }, [conversation?.hasUnread, conversationId, markMessagesAsRead]);
+
+  const onSend = async () => {
+    const trimmed = messageBody.trim();
+    if (!trimmed || !conversationId || isSending) {
+      return;
+    }
+
+    try {
+      setIsSending(true);
+      await sendMessage({ conversationId, body: trimmed });
+      setMessageBody('');
+      scrollToBottom(true);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to send message right now.';
+      Alert.alert('Message failed', message);
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  if (!conversationId) {
+    return (
+      <View style={styles.centeredState}>
+        <Text style={styles.stateTitle}>Conversation not found</Text>
+      </View>
+    );
+  }
+
+  if (
+    authLoading ||
+    (isAuthenticated &&
+      (conversationList === undefined ||
+        currentUserSubject === undefined ||
+        (conversation !== null && messages === undefined)))
+  ) {
+    return (
+      <View style={styles.centeredState}>
+        <ActivityIndicator size="small" color="#154734" />
+        <Text style={styles.stateText}>Loading conversation...</Text>
+      </View>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <View style={styles.centeredState}>
+        <ActivityIndicator size="small" color="#154734" />
+        <Text style={styles.stateText}>Redirecting to login...</Text>
+      </View>
+    );
+  }
+
+  if (!conversation) {
+    return (
+      <View style={styles.centeredState}>
+        <Text style={styles.stateTitle}>Conversation unavailable</Text>
+        <Text style={styles.stateText}>
+          This conversation was not found or you no longer have access.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 82 : 0}
+    >
+      <Stack.Screen
+        options={{
+          title: conversation?.otherUser.name ?? 'Conversation',
+          headerBackTitle: 'Inbox',
+        }}
+      />
+
+      <View style={styles.headerCard}>
+        {conversation?.listing.thumbnailUrl ? (
+          <Image
+            source={{ uri: conversation.listing.thumbnailUrl }}
+            style={styles.headerThumbnail}
+          />
+        ) : (
+          <View style={[styles.headerThumbnail, styles.thumbnailPlaceholder]}>
+            <Text style={styles.thumbnailPlaceholderText}>No Image</Text>
+          </View>
+        )}
+        <View style={styles.headerTextWrap}>
+          <Text style={styles.headerName} numberOfLines={1}>
+            {conversation?.otherUser.name ?? 'User'}
+          </Text>
+          <Text style={styles.headerListing} numberOfLines={1}>
+            {conversation?.listing.title ?? 'Listing unavailable'}
+          </Text>
+          {conversation?.listing.id ? (
+            <Pressable
+              onPress={() => router.push(`/listings/${conversation.listing.id}`)}
+              style={({ pressed }) => [styles.headerListingLink, pressed && styles.buttonPressed]}
+            >
+              <Text style={styles.headerListingLinkText}>View listing</Text>
+            </Pressable>
+          ) : null}
+        </View>
+      </View>
+
+      <FlatList
+        ref={listRef}
+        data={messages ?? []}
+        keyExtractor={(item) => item._id}
+        style={styles.messagesList}
+        contentInsetAdjustmentBehavior="automatic"
+        contentContainerStyle={styles.messagesContent}
+        keyboardShouldPersistTaps="handled"
+        renderItem={({ item }) => {
+          const isSent = item.senderId === currentUserSubject;
+          return (
+            <View
+              style={[
+                styles.messageRow,
+                isSent ? styles.messageRowSent : styles.messageRowReceived,
+              ]}
+            >
+              <View style={[styles.bubble, isSent ? styles.bubbleSent : styles.bubbleReceived]}>
+                <Text
+                  style={[
+                    styles.messageText,
+                    isSent ? styles.messageTextSent : styles.messageTextReceived,
+                  ]}
+                >
+                  {item.body}
+                </Text>
+                <Text
+                  style={[
+                    styles.messageMeta,
+                    isSent ? styles.messageMetaSent : styles.messageMetaReceived,
+                  ]}
+                >
+                  {formatMessageTimestamp(item.createdAt)}
+                </Text>
+              </View>
+            </View>
+          );
+        }}
+        ListEmptyComponent={
+          <View style={styles.emptyState}>
+            <Text style={styles.emptyStateText}>No messages yet. Say hello.</Text>
+          </View>
+        }
+      />
+
+      <View style={styles.composerWrap}>
+        <TextInput
+          value={messageBody}
+          onChangeText={setMessageBody}
+          placeholder="Type a message..."
+          style={styles.input}
+          multiline
+          maxLength={2000}
+          editable={!isSending}
+          textAlignVertical="top"
+        />
+        <Pressable
+          onPress={() => {
+            void onSend();
+          }}
+          style={({ pressed }) => [
+            styles.sendButton,
+            (!messageBody.trim() || isSending) && styles.sendButtonDisabled,
+            pressed && styles.buttonPressed,
+          ]}
+          disabled={!messageBody.trim() || isSending}
+        >
+          <Text style={styles.sendButtonText}>{isSending ? 'Sending...' : 'Send'}</Text>
+        </Pressable>
+      </View>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f3f7f5',
+  },
+  centeredState: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 10,
+    backgroundColor: '#f3f7f5',
+    paddingHorizontal: 20,
+  },
+  stateTitle: {
+    color: '#0f2b21',
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  stateText: {
+    color: '#5a6f65',
+    fontSize: 15,
+  },
+  headerCard: {
+    marginHorizontal: 14,
+    marginTop: 12,
+    marginBottom: 8,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#d8e6df',
+    backgroundColor: '#fff',
+    padding: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  headerThumbnail: {
+    width: 54,
+    height: 54,
+    borderRadius: 10,
+    backgroundColor: '#edf2ef',
+  },
+  thumbnailPlaceholder: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  thumbnailPlaceholderText: {
+    color: '#7d8f85',
+    fontSize: 10,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+  },
+  headerTextWrap: {
+    flex: 1,
+    gap: 2,
+  },
+  headerName: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#0f2b21',
+  },
+  headerListing: {
+    fontSize: 13,
+    color: '#4f645b',
+    fontWeight: '500',
+  },
+  headerListingLink: {
+    alignSelf: 'flex-start',
+    paddingVertical: 3,
+    paddingHorizontal: 8,
+    borderRadius: 999,
+    backgroundColor: '#eef4ff',
+    borderWidth: 1,
+    borderColor: '#d5e4ff',
+  },
+  headerListingLinkText: {
+    color: '#2f5fbd',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  messagesList: {
+    flex: 1,
+  },
+  messagesContent: {
+    paddingHorizontal: 14,
+    paddingTop: 8,
+    paddingBottom: 12,
+    gap: 8,
+  },
+  messageRow: {
+    flexDirection: 'row',
+  },
+  messageRowSent: {
+    justifyContent: 'flex-end',
+  },
+  messageRowReceived: {
+    justifyContent: 'flex-start',
+  },
+  bubble: {
+    maxWidth: '82%',
+    borderRadius: 16,
+    paddingHorizontal: 12,
+    paddingVertical: 9,
+    gap: 4,
+  },
+  bubbleSent: {
+    backgroundColor: '#154734',
+    borderBottomRightRadius: 4,
+  },
+  bubbleReceived: {
+    backgroundColor: '#ffffff',
+    borderWidth: 1,
+    borderColor: '#d8e6df',
+    borderBottomLeftRadius: 4,
+  },
+  messageText: {
+    fontSize: 15,
+    lineHeight: 20,
+  },
+  messageTextSent: {
+    color: '#ffffff',
+  },
+  messageTextReceived: {
+    color: '#173429',
+  },
+  messageMeta: {
+    fontSize: 11,
+    fontVariant: ['tabular-nums'],
+  },
+  messageMetaSent: {
+    color: '#d4e6df',
+  },
+  messageMetaReceived: {
+    color: '#6e8278',
+  },
+  emptyState: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 24,
+  },
+  emptyStateText: {
+    color: '#5f7268',
+    fontSize: 15,
+  },
+  composerWrap: {
+    borderTopWidth: 1,
+    borderTopColor: '#d8e6df',
+    backgroundColor: '#ffffff',
+    paddingHorizontal: 14,
+    paddingTop: 10,
+    paddingBottom: Platform.OS === 'ios' ? 22 : 12,
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: 10,
+  },
+  input: {
+    flex: 1,
+    minHeight: 42,
+    maxHeight: 120,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#d6e3dd',
+    backgroundColor: '#f8fbf9',
+    paddingHorizontal: 12,
+    paddingTop: 10,
+    paddingBottom: 10,
+    fontSize: 15,
+    color: '#173429',
+  },
+  sendButton: {
+    backgroundColor: '#154734',
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 11,
+  },
+  sendButtonDisabled: {
+    opacity: 0.6,
+  },
+  sendButtonText: {
+    color: '#fff',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  buttonPressed: {
+    opacity: 0.9,
+    transform: [{ scale: 0.98 }],
+  },
+});

--- a/frontend/app/conversations/[id].tsx
+++ b/frontend/app/conversations/[id].tsx
@@ -17,6 +17,7 @@ import { useAction, useMutation, useQuery } from 'convex/react';
 import { api } from 'convex/_generated/api';
 import { Id } from 'convex/_generated/dataModel';
 import { useAuth } from '../../hooks/useAuth';
+import { useResolvedImageUrls } from '../../hooks/useResolvedImageUrls';
 
 type ConversationId = Id<'conversations'>;
 
@@ -41,6 +42,7 @@ export default function ConversationDetailScreen() {
   const [isSending, setIsSending] = useState(false);
   const listRef = useRef<FlatList>(null);
   const previousMessageCount = useRef(0);
+  const hasMarkedConversationRef = useRef<string | null>(null);
 
   const currentUserSubject = useQuery(
     api.listings.getCurrentUserSubject,
@@ -57,6 +59,22 @@ export default function ConversationDetailScreen() {
     }
     return conversationList.find((item) => item._id === conversationId) ?? null;
   }, [conversationId, conversationList]);
+
+  const listingId = (conversation?.listing?.id ??
+    conversation?.listingId ??
+    null) as Id<'listings'> | null;
+  const listing = useQuery(api.listings.getListing, listingId ? { id: listingId } : 'skip');
+  const headerThumbnailSource =
+    conversation?.listing?.thumbnailUrl ??
+    (listing?.images && listing.images.length > 0 ? listing.images[0] : null);
+  const { mappedUrls: headerMappedUrls } = useResolvedImageUrls(
+    headerThumbnailSource ? [headerThumbnailSource] : []
+  );
+  const headerThumbnailUrl = headerMappedUrls[0] ?? null;
+  const headerOtherUserName = conversation?.otherUser?.name ?? 'User';
+  const headerConversationTitle = conversation?.otherUser?.name ?? 'Conversation';
+  const headerListingTitle =
+    conversation?.listing?.title ?? listing?.title ?? 'Listing unavailable';
 
   const messages = useQuery(
     api.messages.messagesByConversation,
@@ -91,14 +109,22 @@ export default function ConversationDetailScreen() {
   }, [messages]);
 
   useEffect(() => {
-    if (!conversationId || !conversation?.hasUnread) {
+    if (!conversationId || !isAuthenticated || messages === undefined) {
       return;
     }
 
+    if (hasMarkedConversationRef.current === conversationId) {
+      return;
+    }
+    hasMarkedConversationRef.current = conversationId;
+
     void markMessagesAsRead({ conversationId }).catch(() => {
       // Non-fatal: message stream still renders in real time.
+      if (hasMarkedConversationRef.current === conversationId) {
+        hasMarkedConversationRef.current = null;
+      }
     });
-  }, [conversation?.hasUnread, conversationId, markMessagesAsRead]);
+  }, [conversationId, isAuthenticated, markMessagesAsRead, messages]);
 
   const onSend = async () => {
     const trimmed = messageBody.trim();
@@ -170,17 +196,14 @@ export default function ConversationDetailScreen() {
     >
       <Stack.Screen
         options={{
-          title: conversation?.otherUser.name ?? 'Conversation',
+          title: headerConversationTitle,
           headerBackTitle: 'Inbox',
         }}
       />
 
       <View style={styles.headerCard}>
-        {conversation?.listing.thumbnailUrl ? (
-          <Image
-            source={{ uri: conversation.listing.thumbnailUrl }}
-            style={styles.headerThumbnail}
-          />
+        {headerThumbnailUrl ? (
+          <Image source={{ uri: headerThumbnailUrl }} style={styles.headerThumbnail} />
         ) : (
           <View style={[styles.headerThumbnail, styles.thumbnailPlaceholder]}>
             <Text style={styles.thumbnailPlaceholderText}>No Image</Text>
@@ -188,14 +211,14 @@ export default function ConversationDetailScreen() {
         )}
         <View style={styles.headerTextWrap}>
           <Text style={styles.headerName} numberOfLines={1}>
-            {conversation?.otherUser.name ?? 'User'}
+            {headerOtherUserName}
           </Text>
           <Text style={styles.headerListing} numberOfLines={1}>
-            {conversation?.listing.title ?? 'Listing unavailable'}
+            {headerListingTitle}
           </Text>
-          {conversation?.listing.id ? (
+          {listingId ? (
             <Pressable
-              onPress={() => router.push(`/listings/${conversation.listing.id}`)}
+              onPress={() => router.push(`/listings/${listingId}`)}
               style={({ pressed }) => [styles.headerListingLink, pressed && styles.buttonPressed]}
             >
               <Text style={styles.headerListingLinkText}>View listing</Text>

--- a/frontend/app/conversations/[id].tsx
+++ b/frontend/app/conversations/[id].tsx
@@ -21,6 +21,19 @@ import { useResolvedImageUrls } from '../../hooks/useResolvedImageUrls';
 
 type ConversationId = Id<'conversations'>;
 
+function canonicalParticipantId(value: string) {
+  const [base] = value.split('|');
+  return base;
+}
+
+function isSameParticipantId(left: string, right: string) {
+  return left === right || canonicalParticipantId(left) === canonicalParticipantId(right);
+}
+
+function matchesAnyParticipantId(value: string, candidates: string[]) {
+  return candidates.some((candidate) => isSameParticipantId(value, candidate));
+}
+
 function formatMessageTimestamp(timestamp: number) {
   return new Intl.DateTimeFormat(undefined, {
     hour: 'numeric',
@@ -42,7 +55,7 @@ export default function ConversationDetailScreen() {
   const [isSending, setIsSending] = useState(false);
   const listRef = useRef<FlatList>(null);
   const previousMessageCount = useRef(0);
-  const hasMarkedConversationRef = useRef<string | null>(null);
+  const isMarkingReadRef = useRef(false);
 
   const currentUserSubject = useQuery(
     api.listings.getCurrentUserSubject,
@@ -80,6 +93,18 @@ export default function ConversationDetailScreen() {
     api.messages.messagesByConversation,
     isAuthenticated && conversationId && conversation ? { conversationId } : 'skip'
   );
+  const participantKeys = useMemo(
+    () =>
+      [currentUserSubject, user?._id].filter(
+        (value): value is string => typeof value === 'string' && value.length > 0
+      ),
+    [currentUserSubject, user?._id]
+  );
+  const unreadIncomingCount =
+    messages?.filter(
+      (message) =>
+        message.readAt === 0 && matchesAnyParticipantId(message.recipientId, participantKeys)
+    ).length ?? 0;
 
   const scrollToBottom = (animated: boolean) => {
     requestAnimationFrame(() => {
@@ -109,22 +134,23 @@ export default function ConversationDetailScreen() {
   }, [messages]);
 
   useEffect(() => {
-    if (!conversationId || !isAuthenticated || messages === undefined) {
+    if (!conversationId || !isAuthenticated || unreadIncomingCount === 0) {
       return;
     }
 
-    if (hasMarkedConversationRef.current === conversationId) {
+    if (isMarkingReadRef.current) {
       return;
     }
-    hasMarkedConversationRef.current = conversationId;
+    isMarkingReadRef.current = true;
 
-    void markMessagesAsRead({ conversationId }).catch(() => {
-      // Non-fatal: message stream still renders in real time.
-      if (hasMarkedConversationRef.current === conversationId) {
-        hasMarkedConversationRef.current = null;
-      }
-    });
-  }, [conversationId, isAuthenticated, markMessagesAsRead, messages]);
+    void markMessagesAsRead({ conversationId })
+      .catch(() => {
+        // Non-fatal: message stream still renders in real time.
+      })
+      .finally(() => {
+        isMarkingReadRef.current = false;
+      });
+  }, [conversationId, isAuthenticated, markMessagesAsRead, unreadIncomingCount]);
 
   const onSend = async () => {
     const trimmed = messageBody.trim();
@@ -236,7 +262,8 @@ export default function ConversationDetailScreen() {
         contentContainerStyle={styles.messagesContent}
         keyboardShouldPersistTaps="handled"
         renderItem={({ item }) => {
-          const isSent = item.senderId === currentUserSubject || item.senderId === user?._id;
+          const isSent = matchesAnyParticipantId(item.senderId, participantKeys);
+          const receiptLabel = item.readAt > 0 ? 'Read' : 'Sent';
           return (
             <View
               style={[
@@ -259,7 +286,9 @@ export default function ConversationDetailScreen() {
                     isSent ? styles.messageMetaSent : styles.messageMetaReceived,
                   ]}
                 >
-                  {formatMessageTimestamp(item.createdAt)}
+                  {isSent
+                    ? `${formatMessageTimestamp(item.createdAt)} • ${receiptLabel}`
+                    : formatMessageTimestamp(item.createdAt)}
                 </Text>
               </View>
             </View>

--- a/frontend/app/listings/[id].tsx
+++ b/frontend/app/listings/[id].tsx
@@ -55,6 +55,7 @@ export default function ListingDetailScreen() {
   );
   const getOrCreateConversation = useMutation(api.messages.getOrCreateConversation);
   const [reportOpen, setReportOpen] = useState(false);
+  const [isStartingConversation, setIsStartingConversation] = useState(false);
   const { mappedUrls } = useResolvedImageUrls(listing?.images ?? []);
 
   const navigateToFeedWithTag = (tag: string) => {
@@ -64,11 +65,23 @@ export default function ListingDetailScreen() {
     });
   };
 
-  const openConversation = async () => {
+  const onMessageSellerPress = async () => {
     if (!listing) {
       return;
     }
+
+    if (!isAuthenticated) {
+      const redirectTo = `/listings/${listing._id}`;
+      router.push(`/auth/login?returnTo=${encodeURIComponent(redirectTo)}` as never);
+      return;
+    }
+
+    if (isStartingConversation) {
+      return;
+    }
+
     try {
+      setIsStartingConversation(true);
       const convo = await getOrCreateConversation({ listingId: listing._id });
       router.push({
         pathname: '/messages/[id]',
@@ -76,6 +89,8 @@ export default function ListingDetailScreen() {
       });
     } catch {
       Alert.alert('Unable to start conversation right now.');
+    } finally {
+      setIsStartingConversation(false);
     }
   };
 
@@ -228,26 +243,19 @@ export default function ListingDetailScreen() {
 
         {!isOwner && (
           <View style={styles.buttonContainer}>
-            {!isAuthenticated ? (
-              <Pressable
-                style={({ pressed }) => [styles.messageButton, pressed && styles.buttonPressed]}
-                onPress={() => {
-                  const redirectTo = `/listings/${listing._id}`;
-                  router.push(`/auth/login?returnTo=${encodeURIComponent(redirectTo)}` as never);
-                }}
-              >
-                <Text style={styles.messageButtonText}>Sign in to message seller</Text>
-              </Pressable>
-            ) : (
-              <Pressable
-                style={({ pressed }) => [styles.messageButton, pressed && styles.buttonPressed]}
-                onPress={() => {
-                  void openConversation();
-                }}
-              >
-                <Text style={styles.messageButtonText}>Message Seller</Text>
-              </Pressable>
-            )}
+            <Pressable
+              style={({ pressed }) => [
+                styles.messageButton,
+                isStartingConversation && styles.buttonDisabled,
+                pressed && styles.buttonPressed,
+              ]}
+              onPress={() => {
+                void onMessageSellerPress();
+              }}
+              disabled={isStartingConversation}
+            >
+              <Text style={styles.messageButtonText}>Message Seller</Text>
+            </Pressable>
             <Pressable
               style={({ pressed }) => [styles.reportButton, pressed && styles.buttonPressed]}
               onPress={() => setReportOpen(true)}
@@ -483,6 +491,9 @@ const styles = StyleSheet.create({
   buttonPressed: {
     opacity: 0.92,
     transform: [{ scale: 0.99 }],
+  },
+  buttonDisabled: {
+    opacity: 0.75,
   },
   tagPressed: {
     opacity: 0.85,

--- a/frontend/app/listings/[id].tsx
+++ b/frontend/app/listings/[id].tsx
@@ -84,7 +84,7 @@ export default function ListingDetailScreen() {
       setIsStartingConversation(true);
       const convo = await getOrCreateConversation({ listingId: listing._id });
       router.push({
-        pathname: '/messages/[id]',
+        pathname: '/conversations/[id]',
         params: { id: String(convo.conversationId) },
       });
     } catch {

--- a/frontend/app/messages/[id].tsx
+++ b/frontend/app/messages/[id].tsx
@@ -1,40 +1,19 @@
-import { View, Text, StyleSheet } from 'react-native';
-import { useLocalSearchParams } from 'expo-router';
+import { Redirect, useLocalSearchParams } from 'expo-router';
 
-export default function MessageThreadPlaceholderScreen() {
-  const { id } = useLocalSearchParams<{ id?: string }>();
+export default function LegacyMessagesRouteRedirect() {
+  const { id } = useLocalSearchParams<{ id?: string | string[] }>();
+  const conversationId = typeof id === 'string' && id.trim().length > 0 ? id : null;
+
+  if (!conversationId) {
+    return <Redirect href="/inbox" />;
+  }
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Conversation started</Text>
-      <Text style={styles.subtitle}>Thread ID: {id ?? 'unknown'}</Text>
-      <Text style={styles.body}>
-        Messaging thread UI is being finalized. This confirms the conversation flow was created.
-      </Text>
-    </View>
+    <Redirect
+      href={{
+        pathname: '/conversations/[id]',
+        params: { id: conversationId },
+      }}
+    />
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    padding: 20,
-    justifyContent: 'center',
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: '700',
-    marginBottom: 10,
-  },
-  subtitle: {
-    fontSize: 14,
-    color: '#666',
-    marginBottom: 14,
-  },
-  body: {
-    fontSize: 16,
-    color: '#333',
-    lineHeight: 22,
-  },
-});

--- a/frontend/app/messages/[id].tsx
+++ b/frontend/app/messages/[id].tsx
@@ -1,19 +1,3 @@
-import { Redirect, useLocalSearchParams } from 'expo-router';
+import ConversationDetailScreen from '../conversations/[id]';
 
-export default function LegacyMessagesRouteRedirect() {
-  const { id } = useLocalSearchParams<{ id?: string | string[] }>();
-  const conversationId = typeof id === 'string' && id.trim().length > 0 ? id : null;
-
-  if (!conversationId) {
-    return <Redirect href="/inbox" />;
-  }
-
-  return (
-    <Redirect
-      href={{
-        pathname: '/conversations/[id]',
-        params: { id: conversationId },
-      }}
-    />
-  );
-}
+export default ConversationDetailScreen;


### PR DESCRIPTION
## Linked Issues

Closes #39
Linear: POLY-39

## Summary

- Created the Message Seller entry point on listing detail pages.
- Created the inbox/conversation list screen with real-time data.
- Created the full chat detail screen for individual conversations.

Connected the messaging navigation flow:
- Listing detail → chat
- Inbox → chat

- Added unread indicators/badge support for messaging UI.
- Added message read status display in chat (Sent / Read).

## How to Test

Steps to verify locally:

- `npm run lint`
- `npm run typecheck`
- `npm test`
- Manual flow:
  1. `npm run dev:backend` (in terminal A)
  2. `npm run dev` (in terminal B)
  3. Verify the change: <describe expected behavior/screens>

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Lint/tests pass locally (`npm run lint`)
- [ ] Docs updated (README/ADR/changelog if needed)
- [ ] Follows conventional commit format
- [ ] No merge conflicts with `dev`

## Screenshots / Demos
<img width="1512" height="895" alt="Screenshot 2026-03-06 at 3 48 26 PM" src="https://github.com/user-attachments/assets/3ccf9370-0dac-42f6-9e03-509cb7af6737" />
<img width="755" height="867" alt="Screenshot 2026-03-06 at 3 48 44 PM" src="https://github.com/user-attachments/assets/66519113-8f83-4062-af30-
<img width="758" height="887" alt="Screenshot 2026-03-06 at 3 49 36 PM" src="https://github.com/user-attachments/assets/2bcab98c-4b7f-47ad-80ef-f5333f5519c6" />
e06da6658eda" />
<img width="759" height="892" alt="Screenshot 2026-03-06 at 3 48 53 PM" src="https://github.com/user-attachments/assets/70cee201-00fb-4d16-ad35-6cd4f63a787f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unread badges on Inbox (web & mobile), redesigned Inbox list, full Conversation screen, and streamlined "Message Seller" flow with direct conversation navigation.

* **Bug Fixes**
  * Other participant names resolve correctly when aliases exist.
  * Marking messages as read no longer alters conversation "last updated" timestamps.
  * Message history, unread marking, and listing thumbnails now aggregate and display across related sibling conversations and handle remote/local URLs.

* **Tests**
  * Added tests for alias name resolution, whitespace-only message rejection, sibling-conversation aggregation, and read-mark timestamp behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->