### PR TITLE
feat: misc frontend UI fixes and improvements

### DIFF
--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -157,10 +157,14 @@ export default function HomeScreen() {
 
   const handleCreateListing = () => {
     if (!isAuthenticated) {
-      Alert.alert('Sign In Required', 'Please sign in to create a listing', [
-        { text: 'Cancel', style: 'cancel' },
-        { text: 'Sign In', onPress: () => router.push('/auth/login') },
-      ]);
+      if (Platform.OS === 'web') {
+        router.push('/settings');
+      } else {
+        Alert.alert('Sign In Required', 'Please sign in to create a listing', [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'Sign In', onPress: () => router.push('/auth/login') },
+        ]);
+      }
       return;
     }
     router.push('/listings/new');
@@ -317,7 +321,7 @@ const styles = StyleSheet.create({
     lineHeight: 22,
   },
   createButton: {
-    backgroundColor: '#1c7f50',
+    backgroundColor: '#154734',
     paddingHorizontal: 16,
     paddingVertical: 12,
     borderRadius: 12,

--- a/frontend/app/(tabs)/my-listings.tsx
+++ b/frontend/app/(tabs)/my-listings.tsx
@@ -16,6 +16,7 @@ import { api } from 'convex/_generated/api';
 import type { Doc, Id } from 'convex/_generated/dataModel';
 import { useAuth } from '../../hooks/useAuth';
 import { useEntranceAnimation } from '../../hooks/useEntranceAnimation';
+import { showAlert } from '../../utils/showAlert';
 
 function getStatusLabel(status: Doc<'listings'>['status']) {
   switch (status) {
@@ -43,6 +44,8 @@ export default function MyListingsScreen() {
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
   async function handleDelete(id: string, title: string) {
+    if (deletingId !== null) return;
+
     const confirmed =
       Platform.OS === 'web' && typeof window !== 'undefined'
         ? window.confirm(`Are you sure you want to delete "${title}"? This cannot be undone.`)
@@ -63,11 +66,7 @@ export default function MyListingsScreen() {
       setDeletingId(id);
       await deleteListing({ id: id as Id<'listings'> });
     } catch {
-      if (Platform.OS === 'web' && typeof window !== 'undefined') {
-        window.alert('Failed to delete listing. Please try again.');
-      } else {
-        Alert.alert('Error', 'Failed to delete listing. Please try again.');
-      }
+      showAlert('Error', 'Failed to delete listing. Please try again.');
     } finally {
       setDeletingId(null);
     }
@@ -157,7 +156,7 @@ export default function MyListingsScreen() {
               <Pressable
                 style={({ pressed }) => [styles.deleteButton, pressed && styles.buttonPressed]}
                 onPress={() => handleDelete(item._id, item.title)}
-                disabled={deletingId === item._id}
+                disabled={deletingId !== null}
               >
                 {deletingId === item._id ? (
                   <ActivityIndicator size="small" color="#fff" />

--- a/frontend/app/(tabs)/my-listings.tsx
+++ b/frontend/app/(tabs)/my-listings.tsx
@@ -1,16 +1,19 @@
-import { useQuery } from 'convex/react';
+import { useMutation, useQuery } from 'convex/react';
 import { useRouter } from 'expo-router';
+import { useState } from 'react';
 import {
   ActivityIndicator,
+  Alert,
   Animated,
   FlatList,
+  Platform,
   Pressable,
   StyleSheet,
   Text,
   View,
 } from 'react-native';
 import { api } from 'convex/_generated/api';
-import type { Doc } from 'convex/_generated/dataModel';
+import type { Doc, Id } from 'convex/_generated/dataModel';
 import { useAuth } from '../../hooks/useAuth';
 import { useEntranceAnimation } from '../../hooks/useEntranceAnimation';
 
@@ -36,6 +39,39 @@ export default function MyListingsScreen() {
   const { isAuthenticated, isLoading } = useAuth();
   const entranceStyle = useEntranceAnimation();
   const myListings = useQuery(api.listings.getMyListings, isAuthenticated ? {} : 'skip');
+  const deleteListing = useMutation(api.listings.deleteListing);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  async function handleDelete(id: string, title: string) {
+    const confirmed =
+      Platform.OS === 'web' && typeof window !== 'undefined'
+        ? window.confirm(`Are you sure you want to delete "${title}"? This cannot be undone.`)
+        : await new Promise<boolean>((resolve) =>
+            Alert.alert(
+              'Delete listing',
+              `Are you sure you want to delete "${title}"? This cannot be undone.`,
+              [
+                { text: 'Cancel', style: 'cancel', onPress: () => resolve(false) },
+                { text: 'Delete', style: 'destructive', onPress: () => resolve(true) },
+              ]
+            )
+          );
+
+    if (!confirmed) return;
+
+    try {
+      setDeletingId(id);
+      await deleteListing({ id: id as Id<'listings'> });
+    } catch {
+      if (Platform.OS === 'web' && typeof window !== 'undefined') {
+        window.alert('Failed to delete listing. Please try again.');
+      } else {
+        Alert.alert('Error', 'Failed to delete listing. Please try again.');
+      }
+    } finally {
+      setDeletingId(null);
+    }
+  }
 
   if (!isAuthenticated) {
     return (
@@ -117,6 +153,19 @@ export default function MyListingsScreen() {
             >
               <Text style={styles.primaryButtonText}>Edit</Text>
             </Pressable>
+            {item.status !== 'deleted' && (
+              <Pressable
+                style={({ pressed }) => [styles.deleteButton, pressed && styles.buttonPressed]}
+                onPress={() => handleDelete(item._id, item.title)}
+                disabled={deletingId === item._id}
+              >
+                {deletingId === item._id ? (
+                  <ActivityIndicator size="small" color="#fff" />
+                ) : (
+                  <Text style={styles.deleteButtonText}>Delete</Text>
+                )}
+              </Pressable>
+            )}
           </View>
         </View>
       )}
@@ -294,5 +343,19 @@ const styles = StyleSheet.create({
   buttonPressed: {
     opacity: 0.92,
     transform: [{ scale: 0.985 }],
+  },
+  deleteButton: {
+    backgroundColor: '#b3261e',
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    minHeight: 40,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  deleteButtonText: {
+    color: '#ffffff',
+    fontSize: 14,
+    fontWeight: '600',
   },
 });

--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -35,7 +35,7 @@ export default function SettingsScreen() {
   const [email, setEmail] = useState('');
   const [bio, setBio] = useState('');
   const [major, setMajor] = useState('');
-  const [year, setYear] = useState('2026');
+  const [year, setYear] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSigningOut, setIsSigningOut] = useState(false);
   const [loadedProfileKey, setLoadedProfileKey] = useState<string | null>(null);
@@ -61,7 +61,7 @@ export default function SettingsScreen() {
       setEmail(user?.email ?? '');
       setBio('');
       setMajor('');
-      setYear('2026');
+      setYear('');
     }
 
     setLoadedProfileKey(nextKey);
@@ -216,6 +216,7 @@ export default function SettingsScreen() {
             value={name}
             onChangeText={setName}
             placeholder="Your full name"
+            placeholderTextColor="#9aaa9f"
           />
 
           <Text style={styles.label}>Email *</Text>
@@ -224,6 +225,7 @@ export default function SettingsScreen() {
             value={email}
             onChangeText={setEmail}
             placeholder="you@calpoly.edu"
+            placeholderTextColor="#9aaa9f"
             keyboardType="email-address"
             autoCapitalize="none"
             autoCorrect={false}
@@ -235,6 +237,7 @@ export default function SettingsScreen() {
             value={bio}
             onChangeText={setBio}
             placeholder="Tell others about yourself"
+            placeholderTextColor="#9aaa9f"
             multiline
           />
 
@@ -244,6 +247,7 @@ export default function SettingsScreen() {
             value={major}
             onChangeText={setMajor}
             placeholder="Computer Science"
+            placeholderTextColor="#9aaa9f"
           />
 
           <Text style={styles.label}>Year *</Text>
@@ -252,6 +256,7 @@ export default function SettingsScreen() {
             value={year}
             onChangeText={setYear}
             placeholder="2026"
+            placeholderTextColor="#9aaa9f"
             keyboardType="number-pad"
           />
 
@@ -273,27 +278,23 @@ export default function SettingsScreen() {
         </View>
       )}
 
-      <View style={styles.sectionCard}>
-        <Text style={styles.sectionTitle}>Session</Text>
-        <Text style={styles.sectionBody}>
-          {isAuthenticated
-            ? 'You are signed in and can post or edit listings.'
-            : 'Sign in with your Cal Poly email to post and manage listings.'}
-        </Text>
-        <Pressable
-          style={({ pressed }) => [
-            styles.button,
-            (isSigningOut || isLoading) && styles.buttonDisabled,
-            pressed && styles.buttonPressed,
-          ]}
-          onPress={handleAuthAction}
-          disabled={isSigningOut || isLoading}
-        >
-          <Text style={styles.buttonText}>
-            {isAuthenticated ? (isSigningOut ? 'Signing out...' : 'Sign out') : 'Sign in'}
-          </Text>
-        </Pressable>
-      </View>
+      {isAuthenticated && (
+        <View style={styles.sectionCard}>
+          <Text style={styles.sectionTitle}>Session</Text>
+          <Text style={styles.sectionBody}>You are signed in and can post or edit listings.</Text>
+          <Pressable
+            style={({ pressed }) => [
+              styles.button,
+              (isSigningOut || isLoading) && styles.buttonDisabled,
+              pressed && styles.buttonPressed,
+            ]}
+            onPress={handleAuthAction}
+            disabled={isSigningOut || isLoading}
+          >
+            <Text style={styles.buttonText}>{isSigningOut ? 'Signing out...' : 'Sign out'}</Text>
+          </Pressable>
+        </View>
+      )}
     </ScrollView>
   );
 }

--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -77,7 +77,7 @@ export default function SettingsScreen() {
     setEmail('');
     setBio('');
     setMajor('');
-    setYear('2026');
+    setYear('');
   }, [isAuthenticated]);
 
   const handleAuthAction = async () => {

--- a/frontend/app/listings/[id].tsx
+++ b/frontend/app/listings/[id].tsx
@@ -28,6 +28,10 @@ import { useResolvedImageUrls } from '../../hooks/useResolvedImageUrls';
 type FeedTabHref = '/' | '/search' | '/settings';
 const DEFAULT_APP_ORIGIN = 'https://polybuys.com';
 
+function capitalize(s: string) {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
 function getAppOrigin() {
   const configuredOrigin = process.env.EXPO_PUBLIC_APP_ORIGIN?.trim();
   if (!configuredOrigin) {
@@ -100,6 +104,11 @@ export default function ListingDetailScreen() {
     if (Platform.OS === 'web' && listing && typeof document !== 'undefined') {
       document.title = `${listing.title} - PolyBuys`;
     }
+    return () => {
+      if (Platform.OS === 'web' && typeof document !== 'undefined') {
+        document.title = 'PolyBuys';
+      }
+    };
   }, [listing]);
 
   if (!listingId) {
@@ -191,11 +200,11 @@ export default function ListingDetailScreen() {
         <View style={styles.metaRow}>
           <View style={styles.metaChip}>
             <Text style={styles.metaLabel}>Category</Text>
-            <Text style={styles.metaValue}>{listing.category}</Text>
+            <Text style={styles.metaValue}>{capitalize(listing.category)}</Text>
           </View>
           <View style={styles.metaChip}>
             <Text style={styles.metaLabel}>Condition</Text>
-            <Text style={styles.metaValue}>{listing.condition}</Text>
+            <Text style={styles.metaValue}>{capitalize(listing.condition)}</Text>
           </View>
         </View>
 

--- a/frontend/app/listings/new.tsx
+++ b/frontend/app/listings/new.tsx
@@ -3,6 +3,7 @@ import {
   ActivityIndicator,
   Alert,
   Animated,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -10,7 +11,7 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import { useAction } from 'convex/react';
+import { useAction, useQuery } from 'convex/react';
 import { useRouter } from 'expo-router';
 import { api } from 'convex/_generated/api';
 import ImageUploader from '@/components/ImageUploader';
@@ -21,6 +22,15 @@ import { useEntranceAnimation } from '../../hooks/useEntranceAnimation';
 const categories = ['textbooks', 'electronics', 'furniture', 'tickets', 'other'] as const;
 const conditions = ['new', 'used', 'refurbished'] as const;
 const MODERATION_ERROR_FRAGMENT = 'violates our community guidelines';
+const PROFILE_SETUP_ERROR_FRAGMENT = 'complete your profile setup';
+
+function showAlert(title: string, message: string) {
+  if (Platform.OS === 'web' && typeof window !== 'undefined') {
+    window.alert(`${title}\n\n${message}`);
+  } else {
+    Alert.alert(title, message);
+  }
+}
 
 function getListingActionError(error: unknown, fallbackTitle: string) {
   const rawMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -29,6 +39,14 @@ function getListingActionError(error: unknown, fallbackTitle: string) {
       title: 'Listing needs edits',
       message:
         'Some listing text was flagged by our safety checks. Try rewording the title or description and submit again.',
+    };
+  }
+
+  if (rawMessage.toLowerCase().includes(PROFILE_SETUP_ERROR_FRAGMENT)) {
+    return {
+      title: 'Profile setup required',
+      message:
+        'Please complete your profile setup before creating a listing. Go to your Profile tab to fill in your details.',
     };
   }
 
@@ -43,6 +61,7 @@ export default function NewListingScreen() {
   const createListing = useAction(api.listings.createListing);
   const { isAuthenticated, isLoading } = useAuth();
   const entranceStyle = useEntranceAnimation();
+  const profile = useQuery(api.profiles.getCurrentProfile, isAuthenticated ? {} : 'skip');
 
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
@@ -57,7 +76,7 @@ export default function NewListingScreen() {
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
-      Alert.alert('Sign In Required', 'Please sign in to create a listing');
+      showAlert('Sign In Required', 'Please sign in to create a listing');
       router.replace('/auth/login');
     }
   }, [isAuthenticated, isLoading, router]);
@@ -67,32 +86,45 @@ export default function NewListingScreen() {
       return;
     }
 
+    if (profile === undefined) {
+      showAlert('Please wait', 'Your profile is still loading. Please try again in a moment.');
+      return;
+    }
+
+    if (profile === null) {
+      showAlert(
+        'Profile setup required',
+        'Please complete your profile setup before creating a listing. Go to your Profile tab to fill in your details.'
+      );
+      return;
+    }
+
     const trimmedTitle = title.trim();
     const trimmedDescription = description.trim();
 
     if (!trimmedTitle || trimmedTitle.length < 5) {
-      Alert.alert('Missing fields', 'Title must be at least 5 characters.');
+      showAlert('Missing fields', 'Title must be at least 5 characters.');
       return;
     }
 
     if (!trimmedDescription) {
-      Alert.alert('Missing fields', 'Description is required.');
+      showAlert('Missing fields', 'Description is required.');
       return;
     }
 
     const parsedPrice = Number(price);
     if (!Number.isFinite(parsedPrice) || parsedPrice < 0) {
-      Alert.alert('Invalid price', 'Please enter a valid non-negative price.');
+      showAlert('Invalid price', 'Please enter a valid non-negative price.');
       return;
     }
 
     if (hasPendingUploads) {
-      Alert.alert('Uploads in progress', 'Please wait for image uploads to finish.');
+      showAlert('Uploads in progress', 'Please wait for image uploads to finish.');
       return;
     }
 
     if (images.length < 1 || images.length > 8) {
-      Alert.alert('Invalid images', 'Please upload between 1 and 8 images.');
+      showAlert('Invalid images', 'Please upload between 1 and 8 images.');
       return;
     }
 
@@ -108,11 +140,11 @@ export default function NewListingScreen() {
         images,
         tags,
       });
-      Alert.alert('Success', 'Listing created.');
+      showAlert('Success', 'Listing created.');
       router.replace('/');
     } catch (error) {
       const actionError = getListingActionError(error, 'Create failed');
-      Alert.alert(actionError.title, actionError.message);
+      showAlert(actionError.title, actionError.message);
     } finally {
       submittingRef.current = false;
       setIsSubmitting(false);
@@ -152,6 +184,15 @@ export default function NewListingScreen() {
           Make it clear, detailed, and easy for students to trust.
         </Text>
 
+        {profile === null && (
+          <Pressable style={styles.profileBanner} onPress={() => router.push('/settings')}>
+            <Text style={styles.profileBannerTitle}>⚠️ Profile setup required</Text>
+            <Text style={styles.profileBannerText}>
+              Complete your profile before creating a listing. Tap here to go to your Profile.
+            </Text>
+          </Pressable>
+        )}
+
         <View style={styles.section}>
           <Text style={styles.label}>Title *</Text>
           <TextInput
@@ -159,6 +200,7 @@ export default function NewListingScreen() {
             value={title}
             onChangeText={setTitle}
             placeholder="Enter listing title"
+            placeholderTextColor="#9aaa9f"
             maxLength={100}
           />
         </View>
@@ -170,6 +212,7 @@ export default function NewListingScreen() {
             value={description}
             onChangeText={setDescription}
             placeholder="Describe your item"
+            placeholderTextColor="#9aaa9f"
             multiline
             numberOfLines={4}
           />
@@ -182,6 +225,7 @@ export default function NewListingScreen() {
             value={price}
             onChangeText={setPrice}
             placeholder="0.00"
+            placeholderTextColor="#9aaa9f"
             keyboardType="decimal-pad"
           />
         </View>
@@ -418,5 +462,24 @@ const styles = StyleSheet.create({
   },
   buttonPressed: {
     opacity: 0.9,
+  },
+  profileBanner: {
+    backgroundColor: '#fff8e1',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#ffe082',
+    padding: 14,
+    marginBottom: 8,
+    gap: 4,
+  },
+  profileBannerTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#6d4c00',
+  },
+  profileBannerText: {
+    fontSize: 14,
+    color: '#8d6e0a',
+    lineHeight: 20,
   },
 });

--- a/frontend/app/listings/new.tsx
+++ b/frontend/app/listings/new.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
-  Alert,
   Animated,
-  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -18,19 +16,12 @@ import ImageUploader from '@/components/ImageUploader';
 import TagInput from '../../components/TagInput';
 import { useAuth } from '../../hooks/useAuth';
 import { useEntranceAnimation } from '../../hooks/useEntranceAnimation';
+import { showAlert } from '../../utils/showAlert';
 
 const categories = ['textbooks', 'electronics', 'furniture', 'tickets', 'other'] as const;
 const conditions = ['new', 'used', 'refurbished'] as const;
 const MODERATION_ERROR_FRAGMENT = 'violates our community guidelines';
 const PROFILE_SETUP_ERROR_FRAGMENT = 'complete your profile setup';
-
-function showAlert(title: string, message: string) {
-  if (Platform.OS === 'web' && typeof window !== 'undefined') {
-    window.alert(`${title}\n\n${message}`);
-  } else {
-    Alert.alert(title, message);
-  }
-}
 
 function getListingActionError(error: unknown, fallbackTitle: string) {
   const rawMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/frontend/utils/showAlert.ts
+++ b/frontend/utils/showAlert.ts
@@ -1,0 +1,14 @@
+import { Alert, Platform } from 'react-native';
+
+/**
+ * Cross-platform alert helper.
+ * Uses `window.alert()` on web (since RN `Alert.alert` is invisible in Expo web)
+ * and native `Alert.alert` on iOS/Android.
+ */
+export function showAlert(title: string, message: string) {
+  if (Platform.OS === 'web' && typeof window !== 'undefined') {
+    window.alert(`${title}\n\n${message}`);
+  } else {
+    Alert.alert(title, message);
+  }
+}


### PR DESCRIPTION
## Linked Issues

No linked Linear issue — miscellaneous UI polish.

## Summary

A collection of frontend UI fixes and quality-of-life improvements for the PolyBuys marketplace.

**Profile tab ([settings.tsx](file:///Users/coleh/PolyBuys/frontend/app/%28tabs%29/settings.tsx)):**
- Removed duplicate sign-in messages when logged out (Session card now only shows when authenticated)
- Styled all profile `TextInput` placeholder text with lighter grey (`#9aaa9f`)
- Changed Year field from pre-filled "2026" to empty with placeholder

**Home feed ([index.tsx](file:///Users/coleh/PolyBuys/frontend/app/%28tabs%29/index.tsx)):**
- Unauthenticated users clicking "+ Create Listing" are now redirected to profile tab on web (retains native [Alert](file:///Users/coleh/PolyBuys/frontend/app/listings/new.tsx#27-34) behavior)
- Standardized Create Listing button color to brand green (`#154734`)

**Listing detail (`[id].tsx`):**
- Fixed browser tab title persisting after navigating away from a listing (cleanup resets to "PolyBuys")
- Category and condition values now display with proper capitalization via [capitalize()](file:///Users/coleh/PolyBuys/frontend/app/listings/%5Bid%5D.tsx#31-34) helper

**Create listing ([new.tsx](file:///Users/coleh/PolyBuys/frontend/app/listings/new.tsx)):**
- Added cross-platform [showAlert()](file:///Users/coleh/PolyBuys/frontend/app/listings/new.tsx#27-34) helper — uses `window.alert()` on web since `Alert.alert` is invisible in Expo web
- Replaced all `Alert.alert` calls with [showAlert](file:///Users/coleh/PolyBuys/frontend/app/listings/new.tsx#27-34) so validation messages actually appear on web
- Added upfront profile check — queries profile on mount and blocks submission with friendly message if incomplete
- Added visible yellow warning banner when profile is missing, with tap-to-navigate to Profile tab
- Styled placeholder text with lighter grey to match profile page

**My Listings ([my-listings.tsx](file:///Users/coleh/PolyBuys/frontend/app/%28tabs%29/my-listings.tsx)):**
- Added red **Delete** button to each listing card with confirmation dialog
- Uses `window.confirm()` on web, native [Alert](file:///Users/coleh/PolyBuys/frontend/app/listings/new.tsx#27-34) with Cancel/Delete on mobile
- Shows loading spinner during deletion, hides button for already-deleted listings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete listings with confirmation and loading state
  * Guided profile setup flow when creating listings; prevents submission until profile is ready
* **Bug Fixes**
  * Platform-specific unauthenticated flow: web now redirects to settings, native retains login prompt
  * Session section only shown when authenticated
* **Style**
  * Updated create button color and placeholder text color
  * Capitalized listing category/condition and improved page title handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->