### PR TITLE
centered buttons in profile page

### DIFF
--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -449,6 +449,7 @@ export default function SettingsScreen() {
         <Pressable
           style={({ pressed }) => [
             styles.secondaryButton,
+            styles.footerSignOutButton,
             pressed && styles.buttonPressed,
             (isSigningOut || isLoading) && styles.buttonDisabled,
           ]}
@@ -461,7 +462,7 @@ export default function SettingsScreen() {
         </Pressable>
         <Pressable
           style={({ pressed }) => [
-            styles.deleteButton,
+            styles.footerDeleteButton,
             pressed && styles.buttonPressed,
             isLoading && styles.buttonDisabled,
           ]}
@@ -702,11 +703,15 @@ const styles = StyleSheet.create({
   footer: {
     marginTop: spacing.lg,
     gap: spacing.md,
+    alignItems: 'center',
   },
-  deleteButton: {
-    alignSelf: 'flex-start',
+  footerDeleteButton: {
+    alignItems: 'center',
     paddingVertical: spacing.md,
     paddingHorizontal: 0,
+  },
+  footerSignOutButton: {
+    alignSelf: 'center',
   },
   deleteButtonText: {
     ...typography.subhead,


### PR DESCRIPTION
## Linked Issues

Linear: POLY-64 (e.g., POLY-123)

## Summary

Fix UI Layout of Sign out and Delete Account in Profile Page to be centered and bottom

## How to Test

Steps to verify locally:

- `npm run lint`
- `npm run typecheck`
- `npm test`
- Manual flow:
  1. `npm run dev:backend` (in terminal A)
  2. `npm run dev` (in terminal B)
  3. Verify the change: <describe expected behavior/screens>

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Lint/tests pass locally (`npm run lint`)
- [ ] Docs updated (README/ADR/changelog if needed)
- [ ] Follows conventional commit format
- [ ] No merge conflicts with `dev`

## Screenshots / Demos

(if UI or visible behavior - attach images, videos, or GIFs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted footer button alignment and styling in the settings screen for the "Sign out" and "Delete account" buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->