### PR TITLE
fix(vercel): declare @sentry/react-native in frontend workspace

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -25,11 +25,36 @@ git push -u origin feature/POLY-123-description
 
 ## 📱 Testing on Device
 
-1. Install **Expo Go** on your phone
-2. Run `npm run dev`
-3. Scan QR code:
-   - **iOS**: Use Camera app
-   - **Android**: Use Expo Go app
+1. Install **Expo Go** on your phone (or simulator)
+2. From repo root, run `npm run dev`
+3. In the Expo terminal, press **`s`** if it says you are using a **development build** but you only have Expo Go (avoids "No development build installed")
+4. Scan the QR code:
+   - **iOS**: Camera app or Expo Go
+   - **Android**: Expo Go app
+5. If the phone cannot load the bundle (timeouts), try tunnel mode: `cd frontend && npx expo start --tunnel`
+
+### Expo Go vs development build and npm scripts
+
+**Expo Go** runs your JS in the generic Expo Go app—no native compile. **Development build** is a custom native binary (`expo run:ios` / EAS) with your native plugins.
+
+Scripts are in `frontend/package.json` (root `npm run dev` starts the frontend workspace):
+
+| Script                      | What it does                                                         |
+| --------------------------- | -------------------------------------------------------------------- |
+| `npm run dev` / `npm start` | Starts Metro (Expo dev server).                                      |
+| `npm run ios`               | `expo start --ios` — simulator + Metro (**no** full native compile). |
+| `npm run android`           | `expo start --android` — same for Android.                           |
+| `npm run web`               | `expo start --web`                                                   |
+| `npm run run:ios`           | `expo run:ios` — **native** Xcode build (needs CocoaPods, signing).  |
+| `npm run run:android`       | `expo run:android` — **native** Gradle build.                        |
+
+**First-time iOS native build:** Install [CocoaPods](https://cocoapods.org/). After `expo prebuild` or `run:ios` generates `frontend/ios`, run:
+
+```bash
+cd frontend/ios && pod install && cd ../..
+```
+
+Open `frontend/ios/*.xcworkspace` in Xcode and set **Signing & Capabilities** (Team) if you hit code-signing errors.
 
 ## 🛠️ Common Tasks
 

--- a/README.md
+++ b/README.md
@@ -76,13 +76,29 @@ npm run dev
 
 If you do not have Convex Cloud team access, use the local workflow in [docs/LOCAL_DEV_WITHOUT_CONVEX_ACCOUNT.md](docs/LOCAL_DEV_WITHOUT_CONVEX_ACCOUNT.md) before running the commands above.
 
+### Expo Go vs development build
+
+Most day-to-day work uses **Metro only** (JavaScript bundle). You do **not** need to compile native code unless you are changing native config or debugging something that only reproduces in a custom dev client.
+
+| Goal                                                    | Command (from repo root)                                                                 | Notes                                                                                                                                                                                                        |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Start Metro + open in **Expo Go**                       | `npm run dev`, then press **`s`** to switch to Expo Go, then **`i`** / **`a`** / scan QR | Fastest for most contributors. Install [Expo Go](https://expo.dev/go) on device/simulator.                                                                                                                   |
+| Start Metro + **iOS Simulator** (no native rebuild)     | `npm run dev`, then **`i`** when using Expo Go mode                                      | If you see “No development build installed”, press **`s`** in the terminal to use Expo Go instead.                                                                                                           |
+| Start Metro + **Android** (no native rebuild)           | `cd frontend && npm run android` (or `npm run dev` then **`a`**)                         | Opens emulator with Expo.                                                                                                                                                                                    |
+| **Full native build** (Xcode / Gradle compiles the app) | `cd frontend && npm run run:ios` or `npm run run:android`                                | Use when you need the real dev client, native modules, or first-time `ios/` setup. Requires Xcode (iOS), Android SDK (Android), and **CocoaPods** for iOS (`cd frontend/ios && pod install` after prebuild). |
+
+**iOS troubleshooting:** If `expo run:ios` fails on CocoaPods, install the [CocoaPods CLI](https://cocoapods.org/), then run `pod install` inside `frontend/ios`. For signing errors, open the `.xcworkspace` in Xcode, set your **Team** under Signing & Capabilities, then build from Xcode or retry `run:ios`.
+
+More detail: [QUICK_START.md](QUICK_START.md#expo-go-vs-development-build-and-npm-scripts).
+
 ### Platform-Specific Development
 
 **Mac Users (with Xcode installed):**
 
 ```bash
 npm run dev
-# Press 'i' for iOS Simulator
+# Prefer Expo Go: press s, then i for iOS Simulator
+# Or press w for web
 ```
 
 **Windows/Linux Users:**
@@ -90,7 +106,7 @@ npm run dev
 ```bash
 # Option 1: Android Emulator (requires Android Studio)
 npm run dev
-# Press 'a' for Android
+# Press 'a' for Android (use Expo Go on the emulator if prompted)
 
 # Option 2: Web Browser (easiest, no setup needed)
 npm run dev
@@ -99,9 +115,9 @@ npm run dev
 
 **Testing on Physical Devices:**
 
-- **Android**: Connect via USB with developer mode enabled, run `npm run android`
-- **iOS**: Requires Mac with Xcode
-- **Note**: Expo Go app requires SDK 52 - if you have SDK 54+ installed, use web or emulator instead
+- **Android**: Install Expo Go, run `npm run dev`, scan the QR code from the terminal (or use tunnel: `cd frontend && npx expo start --tunnel` if the device cannot reach your computer).
+- **iOS**: Install Expo Go from the App Store, same flow; on device, you may need tunnel mode on restrictive networks.
+- **Custom dev client**: If the project is configured for a development build, run `cd frontend && npm run run:ios` once to install the native app, then use that client with Metro.
 
 For detailed setup instructions, see [Contributing Guide](docs/contributing.md).
 

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -8,6 +8,7 @@ import { StatusBar } from 'expo-status-bar';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { Platform, useColorScheme } from 'react-native';
+import { FlashProvider } from '../contexts/FlashContext';
 import { usePushNotifications } from '../hooks/usePushNotifications';
 
 const allowSentryPii = process.env.EXPO_PUBLIC_ENABLE_SENTRY_PII === 'true';
@@ -51,52 +52,54 @@ function RootLayout() {
     <SafeAreaProvider>
       <ConvexAuthProvider client={convex} storage={storage}>
         <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-          <PushNotificationsBootstrap />
-          <StatusBar style="auto" />
-          <Stack
-            screenOptions={{
-              headerBackButtonDisplayMode: 'minimal',
-            }}
-          >
-            <Stack.Screen name="(tabs)" options={{ headerShown: false, title: 'Home' }} />
-            <Stack.Screen
-              name="listings/[id]"
-              options={{ title: 'Listing Details', headerBackTitle: 'Back' }}
-            />
-            <Stack.Screen
-              name="listings/new"
-              options={{ title: 'Create Listing', headerBackTitle: 'Back' }}
-            />
-            <Stack.Screen
-              name="listings/[id]/edit"
-              options={{ title: 'Edit Listing', headerBackTitle: 'Back' }}
-            />
-            <Stack.Screen
-              name="messages/[id]"
-              options={{ title: 'Messages', headerBackTitle: 'Back' }}
-            />
-            <Stack.Screen
-              name="conversations/[id]"
-              options={{ title: 'Conversation', headerBackTitle: 'Inbox' }}
-            />
-            <Stack.Screen
-              name="auth/login"
-              options={{
-                title: 'Sign In',
-                headerBackTitle: 'Back',
-                headerShown: Platform.OS !== 'web',
+          <FlashProvider>
+            <PushNotificationsBootstrap />
+            <StatusBar style="auto" />
+            <Stack
+              screenOptions={{
+                headerBackButtonDisplayMode: 'minimal',
               }}
-            />
-            <Stack.Screen
-              name="profile/edit"
-              options={{ title: 'Edit Profile', headerBackTitle: 'Profile' }}
-            />
-            <Stack.Screen
-              name="profile/[userId]"
-              options={{ title: 'Profile', headerBackTitle: 'Back' }}
-            />
-            <Stack.Screen name="l/[id]" options={{ headerShown: false }} />
-          </Stack>
+            >
+              <Stack.Screen name="(tabs)" options={{ headerShown: false, title: 'Home' }} />
+              <Stack.Screen
+                name="listings/[id]"
+                options={{ title: 'Listing Details', headerBackTitle: 'Back' }}
+              />
+              <Stack.Screen
+                name="listings/new"
+                options={{ title: 'Create Listing', headerBackTitle: 'Back' }}
+              />
+              <Stack.Screen
+                name="listings/[id]/edit"
+                options={{ title: 'Edit Listing', headerBackTitle: 'Back' }}
+              />
+              <Stack.Screen
+                name="messages/[id]"
+                options={{ title: 'Messages', headerBackTitle: 'Back' }}
+              />
+              <Stack.Screen
+                name="conversations/[id]"
+                options={{ title: 'Conversation', headerBackTitle: 'Inbox' }}
+              />
+              <Stack.Screen
+                name="auth/login"
+                options={{
+                  title: 'Sign In',
+                  headerBackTitle: 'Back',
+                  headerShown: Platform.OS !== 'web',
+                }}
+              />
+              <Stack.Screen
+                name="profile/edit"
+                options={{ title: 'Edit Profile', headerBackTitle: 'Profile' }}
+              />
+              <Stack.Screen
+                name="profile/[userId]"
+                options={{ title: 'Profile', headerBackTitle: 'Back' }}
+              />
+              <Stack.Screen name="l/[id]" options={{ headerShown: false }} />
+            </Stack>
+          </FlashProvider>
         </ThemeProvider>
       </ConvexAuthProvider>
     </SafeAreaProvider>

--- a/frontend/app/listings/[id].tsx
+++ b/frontend/app/listings/[id].tsx
@@ -23,6 +23,7 @@ import Constants from 'expo-constants';
 import { useMutation, useQuery } from 'convex/react';
 import { api } from 'convex/_generated/api';
 import { Id } from 'convex/_generated/dataModel';
+import { useFlash } from '../../contexts/FlashContext';
 import { useAuth } from '../../hooks/useAuth';
 import HiddenBanner from '../../components/HiddenBanner';
 import ListingUnavailable from '../../components/ListingUnavailable';
@@ -65,6 +66,7 @@ export default function ListingDetailScreen() {
   const { id } = useLocalSearchParams<{ id?: string | string[] }>();
   const listingId = typeof id === 'string' && id.trim().length > 0 ? id : null;
   const router = useRouter();
+  const { setFlash } = useFlash();
   const { isAuthenticated } = useAuth();
   const entranceStyle = useEntranceAnimation();
   const appOrigin = getAppOrigin();
@@ -190,6 +192,7 @@ export default function ListingDetailScreen() {
     try {
       setMarkingSold(true);
       await updateListingStatus({ id: listing._id, status: 'sold' });
+      setFlash('Listing marked as sold.');
     } catch (error) {
       const message =
         error instanceof Error && error.message
@@ -522,6 +525,9 @@ export default function ListingDetailScreen() {
           onClose={() => setReportOpen(false)}
           targetId={String(listing._id)}
           targetType="listing"
+          onReportSuccess={() =>
+            setFlash('Report submitted. Thanks for helping keep PolyBuys safe.')
+          }
         />
       </Animated.View>
     </ScrollView>

--- a/frontend/app/listings/[id]/edit.tsx
+++ b/frontend/app/listings/[id]/edit.tsx
@@ -18,6 +18,7 @@ import type { Id } from 'convex/_generated/dataModel';
 import ImageUploader from '@/components/ImageUploader';
 import ListingUnavailable from '../../../components/ListingUnavailable';
 import TagInput from '../../../components/TagInput';
+import { useFlash } from '../../../contexts/FlashContext';
 import { useEntranceAnimation } from '../../../hooks/useEntranceAnimation';
 import { borderRadius, colors, spacing, typography } from '../../../theme/tokens';
 
@@ -52,6 +53,7 @@ function getListingActionError(error: unknown, fallbackTitle: string) {
 
 export default function EditListingScreen() {
   const router = useRouter();
+  const { setFlash } = useFlash();
   const { id } = useLocalSearchParams<{ id?: string | string[] }>();
   const listingId = typeof id === 'string' && id.trim().length > 0 ? id : null;
   const listing = useQuery(
@@ -148,7 +150,8 @@ export default function EditListingScreen() {
         );
         return;
       }
-      showAlert('Success', 'Listing updated.', () => router.back());
+      setFlash('Listing updated.');
+      router.back();
     } catch (error) {
       const actionError = getListingActionError(error, 'Update failed');
       showAlert(actionError.title, actionError.message);

--- a/frontend/app/listings/new.tsx
+++ b/frontend/app/listings/new.tsx
@@ -16,6 +16,7 @@ import { useRouter } from 'expo-router';
 import { api } from 'convex/_generated/api';
 import ImageUploader from '@/components/ImageUploader';
 import TagInput from '../../components/TagInput';
+import { useFlash } from '../../contexts/FlashContext';
 import { useAuth } from '../../hooks/useAuth';
 import { useEntranceAnimation } from '../../hooks/useEntranceAnimation';
 import { colors, typography, borderRadius, spacing } from '../../theme/tokens';
@@ -60,6 +61,7 @@ function getListingActionError(error: unknown, fallbackTitle: string) {
 
 export default function NewListingScreen() {
   const router = useRouter();
+  const { setFlash } = useFlash();
   const createListing = useAction(api.listings.createListing);
   const { isAuthenticated, isLoading } = useAuth();
   const entranceStyle = useEntranceAnimation();
@@ -143,7 +145,8 @@ export default function NewListingScreen() {
         images,
         tags,
       });
-      showAlert('Success', 'Listing created.', () => router.replace('/'));
+      setFlash('Listing created.');
+      router.replace('/');
     } catch (error) {
       const actionError = getListingActionError(error, 'Create failed');
       showAlert(actionError.title, actionError.message);

--- a/frontend/app/profile/[userId].tsx
+++ b/frontend/app/profile/[userId].tsx
@@ -12,6 +12,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useQuery } from 'convex/react';
 import { api } from 'convex/_generated/api';
 import type { Doc } from 'convex/_generated/dataModel';
+import { useFlash } from '../../contexts/FlashContext';
 import { useAuth } from '../../hooks/useAuth';
 import { useResolvedImageUrls } from '../../hooks/useResolvedImageUrls';
 import ListingCard from '../../components/ListingCard';
@@ -30,6 +31,7 @@ function yearToOrdinal(gradYear: number): string {
 export default function PublicProfileScreen() {
   const { userId: rawUserId } = useLocalSearchParams<{ userId?: string }>();
   const router = useRouter();
+  const { setFlash } = useFlash();
   const { width } = useWindowDimensions();
   const { user, isAuthenticated } = useAuth();
   const [reportOpen, setReportOpen] = useState(false);
@@ -138,6 +140,7 @@ export default function PublicProfileScreen() {
         onClose={() => setReportOpen(false)}
         targetId={profile._id}
         targetType="profile"
+        onReportSuccess={() => setFlash('Report submitted. Thanks for helping keep PolyBuys safe.')}
       />
 
       <Text style={styles.sectionTitle}>Listings</Text>

--- a/frontend/components/ReportModal.tsx
+++ b/frontend/components/ReportModal.tsx
@@ -11,6 +11,8 @@ type ReportModalProps = {
   onClose: () => void;
   targetId: string;
   targetType: 'listing' | 'profile';
+  /** When set, success uses this instead of a blocking alert (e.g. in-app flash banner). */
+  onReportSuccess?: () => void;
 };
 
 const REASONS: { value: ReportReason; label: string; desc: string }[] = [
@@ -21,7 +23,13 @@ const REASONS: { value: ReportReason; label: string; desc: string }[] = [
 
 const MAX_NOTES = 500;
 
-export function ReportModal({ isVisible, onClose, targetId, targetType }: ReportModalProps) {
+export function ReportModal({
+  isVisible,
+  onClose,
+  targetId,
+  targetType,
+  onReportSuccess,
+}: ReportModalProps) {
   const createReport = useMutation(api.reports.createReport);
   const [reason, setReason] = useState<ReportReason | null>(null);
   const [notes, setNotes] = useState('');
@@ -48,7 +56,11 @@ export function ReportModal({ isVisible, onClose, targetId, targetType }: Report
         reason,
         notes: notes.trim() ? notes.trim() : undefined,
       });
-      Alert.alert('Report submitted', 'Thanks for helping keep PolyBuys safe.');
+      if (onReportSuccess) {
+        onReportSuccess();
+      } else {
+        Alert.alert('Report submitted', 'Thanks for helping keep PolyBuys safe.');
+      }
       handleClose();
     } catch (err) {
       const msg = String((err as Error)?.message ?? 'Unable to submit report right now.');

--- a/frontend/contexts/FlashContext.tsx
+++ b/frontend/contexts/FlashContext.tsx
@@ -1,0 +1,117 @@
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+type FlashContextValue = {
+  setFlash: (message: string) => void;
+};
+
+const FlashContext = createContext<FlashContextValue | null>(null);
+
+const FLASH_DURATION_MS = 2000;
+
+export function useFlash() {
+  const ctx = useContext(FlashContext);
+  if (!ctx) {
+    throw new Error('useFlash must be used within FlashProvider');
+  }
+  return ctx;
+}
+
+const BANNER_TOP_OFFSET = 16;
+
+export function FlashProvider({ children }: { children: React.ReactNode }) {
+  const insets = useSafeAreaInsets();
+  const [message, setMessage] = useState<string | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const bannerTop = insets.top + BANNER_TOP_OFFSET;
+
+  const clearFlash = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    setMessage(null);
+  }, []);
+
+  const setFlash = useCallback((msg: string) => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    setMessage(msg);
+    timeoutRef.current = setTimeout(() => {
+      setMessage(null);
+      timeoutRef.current = null;
+    }, FLASH_DURATION_MS);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <FlashContext.Provider value={{ setFlash }}>
+      <View style={styles.wrapper} pointerEvents="box-none">
+        {children}
+        {message ? (
+          <Pressable
+            style={({ pressed }) => [
+              styles.banner,
+              { top: bannerTop },
+              pressed && styles.bannerPressed,
+            ]}
+            onPress={clearFlash}
+            accessibilityRole="alert"
+            accessibilityHint="Double tap to dismiss"
+          >
+            <Text style={styles.text}>{message}</Text>
+            <Text style={styles.dismissHint}>Tap to dismiss</Text>
+          </Pressable>
+        ) : null}
+      </View>
+    </FlashContext.Provider>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    flex: 1,
+  },
+  banner: {
+    position: 'absolute',
+    left: 16,
+    right: 16,
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    backgroundColor: '#166534',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 9999,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.15,
+    shadowRadius: 4,
+    elevation: 4,
+  },
+  bannerPressed: {
+    opacity: 0.92,
+  },
+  text: {
+    fontSize: 14,
+    color: '#fff',
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  dismissHint: {
+    fontSize: 12,
+    color: 'rgba(255,255,255,0.85)',
+    marginTop: 4,
+    fontWeight: '500',
+  },
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@sentry/react-native": "^8.3.0",
     "@convex-dev/auth": "^0.0.90",
     "@expo/metro-runtime": "~55.0.6",
     "@expo/vector-icons": "^15.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "packages/shared"
       ],
       "dependencies": {
-        "@sentry/react-native": "^8.3.0",
         "convex": "^1.32.0"
       },
       "devDependencies": {
@@ -70,6 +69,7 @@
         "@expo/vector-icons": "^15.0.3",
         "@polybuys/shared": "*",
         "@react-native-async-storage/async-storage": "2.2.0",
+        "@sentry/react-native": "^8.3.0",
         "convex": "^1.32.0",
         "expo": "~55.0.5",
         "expo-constants": "~55.0.7",
@@ -5000,7 +5000,7 @@
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6541,7 +6541,7 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -15560,7 +15560,7 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     ]
   },
   "dependencies": {
-    "@sentry/react-native": "^8.3.0",
     "convex": "^1.32.0"
   }
 }


### PR DESCRIPTION
Expo resolves @sentry/react-native/expo from the frontend app; keeping the package only on the root workspace breaks expo export on Vercel.

Made-with: Cursor

## Linked Issues

Closes #<issue-number>
Linear: <linear-issue-key> (e.g., POLY-123)

## Summary

Briefly explain the change and why.

## How to Test

Steps to verify locally:

- `npm run lint`
- `npm run typecheck`
- `npm test`
- Manual flow:
  1. `npm run dev:backend` (in terminal A)
  2. `npm run dev` (in terminal B)
  3. Verify the change: <describe expected behavior/screens>

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Lint/tests pass locally (`npm run lint`)
- [ ] Docs updated (README/ADR/changelog if needed)
- [ ] Follows conventional commit format
- [ ] No merge conflicts with `dev`

## Screenshots / Demos

(if UI or visible behavior - attach images, videos, or GIFs)
