### PR TITLE
feat(frontend): dedicated account settings from profile tab

### DIFF
--- a/backend/convex/blocks.ts
+++ b/backend/convex/blocks.ts
@@ -107,7 +107,7 @@ export const unblockUser = mutation({
 });
 
 /**
- * Users the current account has blocked (for settings / management UI).
+ * Users that the current account has blocked (for settings / management UI).
  * Sorted by display name. Hidden profiles are shown as the placeholder name "Unavailable user"
  * (blockedId is always returned so the user can unblock).
  */
@@ -120,13 +120,21 @@ export const listMyBlockedUsers = query({
       .withIndex('by_blocker_blocked', (q) => q.eq('blockerId', blockerId))
       .collect();
 
-    const rows: BlockedUserListRow[] = [];
+    const blockedIds = [...new Set(blocks.map((b) => b.blockedId))];
+    const profileEntries = await Promise.all(
+      blockedIds.map(async (blockedId) => {
+        const profile = await ctx.db
+          .query('profiles')
+          .withIndex('by_userId', (q) => q.eq('userId', blockedId))
+          .first();
+        return [blockedId, profile] as const;
+      })
+    );
+    const profileByBlockedId = new Map(profileEntries);
 
+    const rows: BlockedUserListRow[] = [];
     for (const block of blocks) {
-      const profile = await ctx.db
-        .query('profiles')
-        .withIndex('by_userId', (q) => q.eq('userId', block.blockedId))
-        .first();
+      const profile = profileByBlockedId.get(block.blockedId);
 
       if (!profile) {
         rows.push({ blockedId: block.blockedId, name: 'Unknown user' });

--- a/backend/convex/blocks.ts
+++ b/backend/convex/blocks.ts
@@ -3,6 +3,12 @@ import { internalQuery, mutation, query } from './_generated/server';
 import type { QueryCtx } from './_generated/server';
 import { requireAuthUserId } from './lib/authIdentity';
 
+type BlockedUserListRow = {
+  blockedId: string;
+  name: string;
+  major?: string;
+};
+
 /**
  * Shared helper: check if there is a block between two users (either direction).
  * Used by internalHasBlockBetween and getOrCreateConversation (mutation) for consistency.
@@ -97,6 +103,47 @@ export const unblockUser = mutation({
     }
 
     return { ok: true };
+  },
+});
+
+/**
+ * Users the current account has blocked (for settings / management UI).
+ * Sorted by display name. Omits hidden profiles but still returns blockedId so they can be unblocked.
+ */
+export const listMyBlockedUsers = query({
+  args: {},
+  handler: async (ctx) => {
+    const blockerId = await requireAuthUserId(ctx);
+    const blocks = await ctx.db
+      .query('userBlocks')
+      .withIndex('by_blocker_blocked', (q) => q.eq('blockerId', blockerId))
+      .collect();
+
+    const rows: BlockedUserListRow[] = [];
+
+    for (const block of blocks) {
+      const profile = await ctx.db
+        .query('profiles')
+        .withIndex('by_userId', (q) => q.eq('userId', block.blockedId))
+        .unique();
+
+      if (!profile) {
+        rows.push({ blockedId: block.blockedId, name: 'Unknown user' });
+        continue;
+      }
+      if (profile.isHidden) {
+        rows.push({ blockedId: block.blockedId, name: 'Unavailable user' });
+        continue;
+      }
+      rows.push({
+        blockedId: block.blockedId,
+        name: profile.name,
+        major: profile.major,
+      });
+    }
+
+    rows.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+    return rows;
   },
 });
 

--- a/backend/convex/blocks.ts
+++ b/backend/convex/blocks.ts
@@ -108,7 +108,8 @@ export const unblockUser = mutation({
 
 /**
  * Users the current account has blocked (for settings / management UI).
- * Sorted by display name. Omits hidden profiles but still returns blockedId so they can be unblocked.
+ * Sorted by display name. Hidden profiles are shown as the placeholder name "Unavailable user"
+ * (blockedId is always returned so the user can unblock).
  */
 export const listMyBlockedUsers = query({
   args: {},
@@ -125,7 +126,7 @@ export const listMyBlockedUsers = query({
       const profile = await ctx.db
         .query('profiles')
         .withIndex('by_userId', (q) => q.eq('userId', block.blockedId))
-        .unique();
+        .first();
 
       if (!profile) {
         rows.push({ blockedId: block.blockedId, name: 'Unknown user' });

--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
-  Alert,
   Animated,
   Image,
   Platform,
@@ -12,9 +11,7 @@ import {
   useWindowDimensions,
 } from 'react-native';
 import { useMutation, usePaginatedQuery, useQuery } from 'convex/react';
-import { Switch } from 'react-native';
-import { requestPermissionAndSyncToken } from '../../hooks/usePushNotifications';
-import { useRouter, type Href } from 'expo-router';
+import { useRouter } from 'expo-router';
 import { api } from 'convex/_generated/api';
 import { useAuth } from '../../hooks/useAuth';
 import { useEntranceAnimation } from '../../hooks/useEntranceAnimation';
@@ -35,19 +32,17 @@ function yearToOrdinal(gradYear: number): string {
 
 type TabId = 'listings' | 'saved';
 
-const PROFILE_EDIT: Href = '/profile/edit';
+const PROFILE_EDIT = '/profile/edit';
+const ACCOUNT_SETTINGS = '/account-settings';
+
 export default function SettingsScreen() {
   const router = useRouter();
   const { width } = useWindowDimensions();
   const isWeb = Platform.OS === 'web';
-  const { isAuthenticated, isLoading, signOut } = useAuth();
+  const { isAuthenticated, isLoading } = useAuth();
   const entranceStyle = useEntranceAnimation();
-  const signOutInProgressRef = useRef(false);
 
   const [activeTab, setActiveTab] = useState<TabId>('listings');
-  const [isSigningOut, setIsSigningOut] = useState(false);
-  const [messageNotificationsValue, setMessageNotificationsValue] = useState(true);
-  const [isUpdatingMessageNotifications, setIsUpdatingMessageNotifications] = useState(false);
   const profile = useQuery(api.profiles.getCurrentProfile, isAuthenticated && !isWeb ? {} : 'skip');
   const myListings = useQuery(api.listings.getMyListings, isAuthenticated && !isWeb ? {} : 'skip');
   const savedArgs = isAuthenticated && !isWeb && activeTab === 'saved' ? {} : 'skip';
@@ -57,16 +52,6 @@ export default function SettingsScreen() {
     loadMore: loadMoreSavedListings,
   } = usePaginatedQuery(api.savedListings.getMySavedListings, savedArgs, { initialNumItems: 20 });
   const toggleSavedListing = useMutation(api.savedListings.toggleSavedListing);
-  const messageNotificationsEnabled = useQuery(
-    api.users.getMessageNotificationsEnabled,
-    isAuthenticated && !isWeb ? {} : 'skip'
-  );
-  const updateMessageNotificationsEnabled = useMutation(
-    api.users.updateMessageNotificationsEnabled
-  );
-  const recordPushToken = useMutation(api.pushNotifications.recordPushToken);
-  const removePushToken = useMutation(api.pushNotifications.removePushToken);
-  const deleteAccount = useMutation(api.users.deleteAccount);
   const { mappedUrls: avatarUrls } = useResolvedImageUrls(
     profile?.picture ? [profile.picture] : []
   );
@@ -83,145 +68,6 @@ export default function SettingsScreen() {
       router.replace('/auth/login?returnTo=%2Fsettings' as never);
     }
   }, [isAuthenticated, isLoading, isWeb, router]);
-
-  useEffect(() => {
-    if (typeof messageNotificationsEnabled === 'boolean') {
-      setMessageNotificationsValue(messageNotificationsEnabled);
-    }
-  }, [messageNotificationsEnabled]);
-
-  const handleAuthAction = async () => {
-    if (!isAuthenticated) {
-      router.replace('/auth/login?returnTo=%2Fsettings' as never);
-      return;
-    }
-
-    if (signOutInProgressRef.current) {
-      return;
-    }
-
-    try {
-      signOutInProgressRef.current = true;
-      setIsSigningOut(true);
-      await signOut();
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to sign out';
-      Alert.alert('Sign Out Failed', message);
-    } finally {
-      signOutInProgressRef.current = false;
-      setIsSigningOut(false);
-    }
-  };
-
-  const handleDeleteAccount = () => {
-    Alert.alert(
-      'Delete account',
-      'Are you sure? This will permanently delete your account and all your data. You can always sign back up later.',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Delete account',
-          style: 'destructive',
-          onPress: async () => {
-            try {
-              await deleteAccount({});
-            } catch (error) {
-              const message = error instanceof Error ? error.message : 'Failed to delete account';
-              Alert.alert('Delete Account Failed', message);
-              return;
-            }
-
-            try {
-              await signOut();
-            } catch (error) {
-              const details = error instanceof Error ? `\n\nDetails: ${error.message}` : '';
-              Alert.alert(
-                'Account Deleted',
-                `Your account was deleted, but we could not sign you out automatically. Please sign out manually.${details}`
-              );
-            }
-          },
-        },
-      ]
-    );
-  };
-
-  const handleMessageNotificationsToggle = async (value: boolean) => {
-    if (isUpdatingMessageNotifications) return;
-
-    const previousValue = messageNotificationsValue;
-    setMessageNotificationsValue(value);
-    setIsUpdatingMessageNotifications(true);
-
-    try {
-      if (value) {
-        let permissionGranted = false;
-        try {
-          permissionGranted = await requestPermissionAndSyncToken(recordPushToken);
-        } catch (error) {
-          setMessageNotificationsValue(previousValue);
-          const message =
-            error instanceof Error ? error.message : 'Unable to enable notifications right now.';
-          Alert.alert('Notification Update Failed', message);
-          return;
-        }
-
-        if (!permissionGranted) {
-          setMessageNotificationsValue(previousValue);
-          Alert.alert(
-            'Notification Update Failed',
-            'Push permission was not granted. Enable notifications in system settings and try again.'
-          );
-          return;
-        }
-
-        await updateMessageNotificationsEnabled({ enabled: true });
-      } else {
-        let removePushTokenSucceeded = false;
-        let removePushTokenError: unknown = null;
-        try {
-          await removePushToken({});
-          removePushTokenSucceeded = true;
-        } catch (error) {
-          removePushTokenError = error;
-        }
-
-        try {
-          await updateMessageNotificationsEnabled({ enabled: false });
-        } catch (error) {
-          const updatePreferenceMessage =
-            error instanceof Error ? error.message : 'Failed to update notification preference';
-
-          if (removePushTokenSucceeded) {
-            Alert.alert(
-              'Notification partially updated',
-              `This device push token was removed, but we could not save your notification preference.\n\nDetails: ${updatePreferenceMessage}`
-            );
-            return;
-          }
-
-          setMessageNotificationsValue(previousValue);
-          const removeTokenMessage =
-            removePushTokenError instanceof Error
-              ? removePushTokenError.message
-              : 'Failed to remove this device push token.';
-
-          Alert.alert(
-            'Notification Update Failed',
-            `We could not disable notifications.\n\nToken removal: ${removeTokenMessage}\nPreference update: ${updatePreferenceMessage}`
-          );
-          return;
-        }
-      }
-    } catch (error) {
-      setMessageNotificationsValue(previousValue);
-      const message =
-        error instanceof Error ? error.message : 'Failed to update notification preference';
-      Alert.alert('Notification Update Failed', message);
-    } finally {
-      setIsUpdatingMessageNotifications(false);
-    }
-  };
 
   if (isWeb) {
     return (
@@ -266,9 +112,18 @@ export default function SettingsScreen() {
           </Text>
           <Pressable
             style={({ pressed }) => [styles.primaryButton, pressed && styles.buttonPressed]}
-            onPress={() => router.push(PROFILE_EDIT)}
+            onPress={() => router.push(PROFILE_EDIT as never)}
           >
             <Text style={styles.primaryButtonText}>Set up profile</Text>
+          </Pressable>
+          <Pressable
+            style={({ pressed }) => [styles.settingsRow, pressed && styles.buttonPressed]}
+            onPress={() => router.push(ACCOUNT_SETTINGS as never)}
+            accessibilityRole="button"
+            accessibilityLabel="Account settings"
+          >
+            <Text style={styles.settingsRowLabel}>Account settings</Text>
+            <Text style={styles.settingsRowChevron}>›</Text>
           </Pressable>
         </Animated.View>
       </ScrollView>
@@ -317,7 +172,7 @@ export default function SettingsScreen() {
             <Text style={styles.bioText}>{profile.bio}</Text>
             <Pressable
               style={({ pressed }) => [styles.editIcon, pressed && { opacity: 0.7 }]}
-              onPress={() => router.push(PROFILE_EDIT)}
+              onPress={() => router.push(PROFILE_EDIT as never)}
               accessibilityLabel="Edit profile"
               accessibilityRole="button"
             >
@@ -327,7 +182,7 @@ export default function SettingsScreen() {
         ) : (
           <Pressable
             style={({ pressed }) => [styles.addBioRow, pressed && { opacity: 0.7 }]}
-            onPress={() => router.push(PROFILE_EDIT)}
+            onPress={() => router.push(PROFILE_EDIT as never)}
           >
             <Text style={styles.addBioText}>Add a bio...</Text>
             <Text style={styles.editIconText}>✎</Text>
@@ -345,22 +200,18 @@ export default function SettingsScreen() {
         */}
       </Animated.View>
 
-      <View style={styles.notificationsSection}>
-        <Text style={styles.sectionTitle}>Notifications</Text>
-        <View style={styles.notificationRow}>
-          <Text style={styles.notificationLabel}>Message notifications</Text>
-          <Switch
-            value={messageNotificationsValue}
-            onValueChange={(value) => void handleMessageNotificationsToggle(value)}
-            disabled={isUpdatingMessageNotifications || messageNotificationsEnabled === undefined}
-            trackColor={{ false: colors.border, true: colors.primary }}
-            thumbColor={colors.white}
-          />
+      <Pressable
+        style={({ pressed }) => [styles.settingsRowCard, pressed && styles.buttonPressed]}
+        onPress={() => router.push(ACCOUNT_SETTINGS as never)}
+        accessibilityRole="button"
+        accessibilityLabel="Open settings"
+      >
+        <View style={styles.settingsRowTextBlock}>
+          <Text style={styles.settingsRowLabel}>Settings</Text>
+          <Text style={styles.settingsRowSubtext}>Notifications, sign out, and account</Text>
         </View>
-        <Text style={styles.notificationHint}>
-          Get notified when someone messages you about a listing.
-        </Text>
-      </View>
+        <Text style={styles.settingsRowChevron}>›</Text>
+      </Pressable>
 
       <View style={styles.tabs}>
         <Pressable
@@ -444,33 +295,6 @@ export default function SettingsScreen() {
           )}
         </View>
       )}
-
-      <View style={styles.footer}>
-        <Pressable
-          style={({ pressed }) => [
-            styles.secondaryButton,
-            pressed && styles.buttonPressed,
-            (isSigningOut || isLoading) && styles.buttonDisabled,
-          ]}
-          onPress={handleAuthAction}
-          disabled={isSigningOut || isLoading}
-        >
-          <Text style={styles.secondaryButtonText}>
-            {isSigningOut ? 'Signing out...' : 'Sign out'}
-          </Text>
-        </Pressable>
-        <Pressable
-          style={({ pressed }) => [
-            styles.deleteButton,
-            pressed && styles.buttonPressed,
-            isLoading && styles.buttonDisabled,
-          ]}
-          onPress={handleDeleteAccount}
-          disabled={isLoading}
-        >
-          <Text style={styles.deleteButtonText}>Delete account</Text>
-        </Pressable>
-      </View>
     </ScrollView>
   );
 }
@@ -583,30 +407,41 @@ const styles = StyleSheet.create({
     ...typography.footnote,
     color: colors.text,
   },
-  notificationsSection: {
+  settingsRowCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
     backgroundColor: colors.surface,
     borderRadius: borderRadius.xl,
     borderWidth: 1,
     borderColor: colors.border,
-    padding: spacing.xl,
-    gap: spacing.sm,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.lg,
+    gap: spacing.md,
   },
-  sectionTitle: {
-    ...typography.heading,
-    color: colors.textDark,
+  settingsRowTextBlock: {
+    flex: 1,
+    gap: 2,
   },
-  notificationRow: {
+  settingsRow: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
+    marginTop: spacing.md,
+    paddingVertical: spacing.sm,
   },
-  notificationLabel: {
-    ...typography.body,
-    color: colors.text,
+  settingsRowLabel: {
+    ...typography.subhead,
+    fontWeight: '600',
+    color: colors.textDark,
   },
-  notificationHint: {
+  settingsRowSubtext: {
     ...typography.footnote,
     color: colors.muted,
+  },
+  settingsRowChevron: {
+    fontSize: 22,
+    color: colors.muted,
+    fontWeight: '300',
   },
   bioRow: {
     flexDirection: 'row',
@@ -699,20 +534,6 @@ const styles = StyleSheet.create({
     color: colors.text,
     textAlign: 'center',
   },
-  footer: {
-    marginTop: spacing.lg,
-    gap: spacing.md,
-  },
-  deleteButton: {
-    alignSelf: 'flex-start',
-    paddingVertical: spacing.md,
-    paddingHorizontal: 0,
-  },
-  deleteButtonText: {
-    ...typography.subhead,
-    color: colors.destructive,
-    fontWeight: '600',
-  },
   primaryButton: {
     backgroundColor: colors.primary,
     borderRadius: borderRadius.md,
@@ -745,8 +566,5 @@ const styles = StyleSheet.create({
   buttonPressed: {
     opacity: 0.92,
     transform: [{ scale: 0.99 }],
-  },
-  buttonDisabled: {
-    opacity: 0.7,
   },
 });

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -88,6 +88,10 @@ function RootLayout() {
               }}
             />
             <Stack.Screen
+              name="account-settings"
+              options={{ title: 'Settings', headerBackTitle: 'Profile' }}
+            />
+            <Stack.Screen
               name="profile/edit"
               options={{ title: 'Edit Profile', headerBackTitle: 'Profile' }}
             />

--- a/frontend/app/account-settings.tsx
+++ b/frontend/app/account-settings.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { ListRenderItem } from 'react-native';
 import {
+  ActivityIndicator,
   Alert,
+  FlatList,
   Platform,
   Pressable,
-  ScrollView,
   StyleSheet,
   Switch,
   Text,
@@ -18,6 +20,12 @@ import OpenInAppPrompt from '../components/OpenInAppPrompt';
 import { ScreenState } from '../components/ScreenState';
 import { borderRadius, colors, spacing, typography } from '../theme/tokens';
 
+type BlockedRow = {
+  blockedId: string;
+  name: string;
+  major?: string;
+};
+
 export default function AccountSettingsScreen() {
   const router = useRouter();
   const isWeb = Platform.OS === 'web';
@@ -27,9 +35,14 @@ export default function AccountSettingsScreen() {
   const [isSigningOut, setIsSigningOut] = useState(false);
   const [messageNotificationsValue, setMessageNotificationsValue] = useState(true);
   const [isUpdatingMessageNotifications, setIsUpdatingMessageNotifications] = useState(false);
+  const [unblockingId, setUnblockingId] = useState<string | null>(null);
 
   const messageNotificationsEnabled = useQuery(
     api.users.getMessageNotificationsEnabled,
+    isAuthenticated && !isWeb ? {} : 'skip'
+  );
+  const blockedUsers = useQuery(
+    api.blocks.listMyBlockedUsers,
     isAuthenticated && !isWeb ? {} : 'skip'
   );
   const updateMessageNotificationsEnabled = useMutation(
@@ -38,6 +51,7 @@ export default function AccountSettingsScreen() {
   const recordPushToken = useMutation(api.pushNotifications.recordPushToken);
   const removePushToken = useMutation(api.pushNotifications.removePushToken);
   const deleteAccount = useMutation(api.users.deleteAccount);
+  const unblockUser = useMutation(api.blocks.unblockUser);
 
   useEffect(() => {
     if (!isWeb && !isLoading && !isAuthenticated) {
@@ -106,6 +120,38 @@ export default function AccountSettingsScreen() {
       ]
     );
   };
+
+  const confirmUnblock = useCallback(
+    (row: BlockedRow) => {
+      Alert.alert(
+        'Unblock',
+        `Allow ${row.name} to message you again?`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Unblock',
+            onPress: () => {
+              void (async () => {
+                setUnblockingId(row.blockedId);
+                try {
+                  await unblockUser({ blockedId: row.blockedId });
+                } catch (err) {
+                  Alert.alert(
+                    'Could not unblock',
+                    err instanceof Error ? err.message : 'Please try again.'
+                  );
+                } finally {
+                  setUnblockingId(null);
+                }
+              })();
+            },
+          },
+        ],
+        { cancelable: true }
+      );
+    },
+    [unblockUser]
+  );
 
   const handleMessageNotificationsToggle = async (value: boolean) => {
     if (isUpdatingMessageNotifications) return;
@@ -184,11 +230,76 @@ export default function AccountSettingsScreen() {
     }
   };
 
+  const blockedListCount = blockedUsers?.length ?? 0;
+
+  const renderBlockedItem: ListRenderItem<BlockedRow> = useCallback(
+    ({ item, index }) => {
+      const busy = unblockingId === item.blockedId;
+      const isFirst = index === 0;
+      const isLast = index === blockedListCount - 1;
+      return (
+        <View
+          style={[
+            styles.blockedRow,
+            isFirst && styles.blockedRowFirst,
+            isLast && styles.blockedRowLast,
+            !isLast && styles.blockedRowWithSeparator,
+          ]}
+        >
+          <View style={styles.blockedRowText}>
+            <Text style={styles.blockedName} numberOfLines={1}>
+              {item.name}
+            </Text>
+            {item.major ? (
+              <Text style={styles.blockedMajor} numberOfLines={1}>
+                {item.major}
+              </Text>
+            ) : null}
+          </View>
+          <Pressable
+            style={({ pressed }) => [
+              styles.unblockButton,
+              pressed && styles.buttonPressed,
+              busy && styles.buttonDisabled,
+            ]}
+            onPress={() => confirmUnblock(item)}
+            disabled={busy}
+            accessibilityRole="button"
+            accessibilityLabel={`Unblock ${item.name}`}
+          >
+            {busy ? (
+              <ActivityIndicator color={colors.primary} size="small" />
+            ) : (
+              <Text style={styles.unblockButtonText}>Unblock</Text>
+            )}
+          </Pressable>
+        </View>
+      );
+    },
+    [blockedListCount, confirmUnblock, unblockingId]
+  );
+
+  const listEmpty = useCallback(() => {
+    if (blockedUsers === undefined) {
+      return (
+        <View style={[styles.blockedListCard, styles.blockedListEmpty]}>
+          <ActivityIndicator color={colors.primary} />
+          <Text style={styles.blockedListEmptyText}>Loading blocked users…</Text>
+        </View>
+      );
+    }
+    return (
+      <View style={[styles.blockedListCard, styles.blockedListEmpty]}>
+        <Text style={styles.blockedListEmptyText}>You have not blocked anyone.</Text>
+      </View>
+    );
+  }, [blockedUsers]);
+
   if (isWeb) {
     return (
       <OpenInAppPrompt
         title="Open account settings in the mobile app"
-        body="Notification preferences, sign out, and account deletion are available in the PolyBuys mobile app."
+        body="Notification preferences, blocked users, sign out, and account deletion are available in the PolyBuys mobile app."
         path="/account-settings"
         buttonLabel="Open in app"
         secondaryActionLabel="Back to home"
@@ -206,57 +317,78 @@ export default function AccountSettingsScreen() {
   }
 
   return (
-    <ScrollView
+    <FlatList
       style={styles.container}
-      contentInsetAdjustmentBehavior="automatic"
-      contentContainerStyle={styles.content}
-    >
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Notifications</Text>
-        <View style={styles.notificationRow}>
-          <Text style={styles.notificationLabel}>Message notifications</Text>
-          <Switch
-            value={messageNotificationsValue}
-            onValueChange={(value) => void handleMessageNotificationsToggle(value)}
-            disabled={isUpdatingMessageNotifications || messageNotificationsEnabled === undefined}
-            trackColor={{ false: colors.border, true: colors.primary }}
-            thumbColor={colors.white}
-          />
-        </View>
-        <Text style={styles.notificationHint}>
-          Get notified when someone messages you about a listing.
-        </Text>
-      </View>
+      contentContainerStyle={styles.listContent}
+      data={(blockedUsers ?? []) as BlockedRow[]}
+      extraData={blockedListCount}
+      keyExtractor={(item) => item.blockedId}
+      renderItem={renderBlockedItem}
+      ListHeaderComponent={
+        <>
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Notifications</Text>
+            <View style={styles.notificationRow}>
+              <Text style={styles.notificationLabel}>Message notifications</Text>
+              <Switch
+                value={messageNotificationsValue}
+                onValueChange={(value) => void handleMessageNotificationsToggle(value)}
+                disabled={
+                  isUpdatingMessageNotifications || messageNotificationsEnabled === undefined
+                }
+                trackColor={{ false: colors.border, true: colors.primary }}
+                thumbColor={colors.white}
+              />
+            </View>
+            <Text style={styles.notificationHint}>
+              Get notified when someone messages you about a listing.
+            </Text>
+          </View>
 
-      <View style={styles.footer}>
-        <Pressable
-          style={({ pressed }) => [
-            styles.secondaryButton,
-            pressed && styles.buttonPressed,
-            (isSigningOut || isLoading) && styles.buttonDisabled,
-          ]}
-          onPress={() => void handleSignOut()}
-          disabled={isSigningOut || isLoading}
-        >
-          <Text style={styles.secondaryButtonText}>
-            {isSigningOut ? 'Signing out...' : 'Sign out'}
-          </Text>
-        </Pressable>
-        <Pressable
-          style={({ pressed }) => [
-            styles.deleteButton,
-            pressed && styles.deleteButtonPressed,
-            isLoading && styles.buttonDisabled,
-          ]}
-          onPress={handleDeleteAccount}
-          disabled={isLoading}
-          accessibilityRole="button"
-          accessibilityLabel="Delete account permanently"
-        >
-          <Text style={styles.deleteButtonText}>Delete account</Text>
-        </Pressable>
-      </View>
-    </ScrollView>
+          <View style={[styles.section, styles.blockedIntroSection]}>
+            <Text style={styles.sectionTitle}>Blocked users</Text>
+            <Text style={styles.notificationHint}>
+              People you have blocked cannot message you. Unblock someone to allow conversations
+              with them again.
+            </Text>
+          </View>
+        </>
+      }
+      ListEmptyComponent={listEmpty}
+      ListFooterComponent={
+        <View style={styles.footerRow}>
+          <Pressable
+            style={({ pressed }) => [
+              styles.secondaryButton,
+              styles.footerButtonHalf,
+              pressed && styles.buttonPressed,
+              (isSigningOut || isLoading) && styles.buttonDisabled,
+            ]}
+            onPress={() => void handleSignOut()}
+            disabled={isSigningOut || isLoading}
+          >
+            <Text style={styles.secondaryButtonText}>
+              {isSigningOut ? 'Signing out...' : 'Sign out'}
+            </Text>
+          </Pressable>
+          <Pressable
+            style={({ pressed }) => [
+              styles.deleteButton,
+              styles.footerButtonHalf,
+              pressed && styles.deleteButtonPressed,
+              isLoading && styles.buttonDisabled,
+            ]}
+            onPress={handleDeleteAccount}
+            disabled={isLoading}
+            accessibilityRole="button"
+            accessibilityLabel="Delete account permanently"
+          >
+            <Text style={styles.deleteButtonText}>Delete account</Text>
+          </Pressable>
+        </View>
+      }
+      keyboardShouldPersistTaps="handled"
+    />
   );
 }
 
@@ -272,14 +404,15 @@ const styles = StyleSheet.create({
     backgroundColor: colors.background,
     gap: spacing.sm,
   },
-  content: {
+  listContent: {
     width: '100%',
     maxWidth: 980,
     alignSelf: 'center',
     paddingHorizontal: spacing.lg,
     paddingTop: spacing.lg,
     paddingBottom: spacing.xxl,
-    gap: spacing.lg,
+    gap: 0,
+    flexGrow: 1,
   },
   section: {
     backgroundColor: colors.surface,
@@ -288,6 +421,17 @@ const styles = StyleSheet.create({
     borderColor: colors.border,
     padding: spacing.xl,
     gap: spacing.sm,
+    marginBottom: spacing.lg,
+  },
+  blockedIntroSection: {
+    marginBottom: spacing.sm,
+  },
+  blockedListCard: {
+    backgroundColor: colors.surface,
+    borderRadius: borderRadius.xl,
+    borderWidth: 1,
+    borderColor: colors.border,
+    overflow: 'hidden',
   },
   sectionTitle: {
     ...typography.heading,
@@ -306,17 +450,87 @@ const styles = StyleSheet.create({
     ...typography.footnote,
     color: colors.muted,
   },
-  footer: {
-    marginTop: spacing.md,
+  blockedListEmpty: {
+    paddingVertical: spacing.xl,
+    paddingHorizontal: spacing.md,
+    alignItems: 'center',
+    gap: spacing.sm,
+    minHeight: 88,
+  },
+  blockedListEmptyText: {
+    ...typography.subhead,
+    color: colors.muted,
+    textAlign: 'center',
+  },
+  blockedRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
     gap: spacing.md,
-    alignSelf: 'flex-start',
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.lg,
+    backgroundColor: colors.surface,
+    borderLeftWidth: 1,
+    borderRightWidth: 1,
+    borderColor: colors.border,
+  },
+  blockedRowFirst: {
+    borderTopWidth: 1,
+    borderTopLeftRadius: borderRadius.xl,
+    borderTopRightRadius: borderRadius.xl,
+  },
+  blockedRowLast: {
+    borderBottomWidth: 1,
+    borderBottomLeftRadius: borderRadius.xl,
+    borderBottomRightRadius: borderRadius.xl,
+  },
+  blockedRowWithSeparator: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+  },
+  blockedRowText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  blockedName: {
+    ...typography.subhead,
+    fontWeight: '600',
+    color: colors.textDark,
+  },
+  blockedMajor: {
+    ...typography.footnote,
+    color: colors.muted,
+    marginTop: 2,
+  },
+  unblockButton: {
+    minWidth: 96,
+    minHeight: 40,
+    paddingHorizontal: spacing.md,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    borderColor: colors.primary,
+  },
+  unblockButtonText: {
+    ...typography.footnote,
+    fontWeight: '600',
+    color: colors.primary,
+  },
+  footerRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginTop: spacing.lg,
     alignItems: 'stretch',
+  },
+  footerButtonHalf: {
+    flex: 1,
+    minWidth: 0,
   },
   deleteButton: {
     borderWidth: 2,
     borderColor: colors.destructive,
     borderRadius: borderRadius.md,
-    paddingHorizontal: spacing.xl,
+    paddingHorizontal: spacing.md,
     paddingVertical: spacing.md,
     minHeight: 44,
     justifyContent: 'center',
@@ -331,12 +545,13 @@ const styles = StyleSheet.create({
     ...typography.subhead,
     color: colors.destructive,
     fontWeight: '600',
+    textAlign: 'center',
   },
   secondaryButton: {
     borderWidth: 1,
     borderColor: colors.primary,
     borderRadius: borderRadius.md,
-    paddingHorizontal: spacing.xl,
+    paddingHorizontal: spacing.md,
     paddingVertical: spacing.md,
     minHeight: 44,
     justifyContent: 'center',
@@ -346,6 +561,7 @@ const styles = StyleSheet.create({
     ...typography.subhead,
     fontWeight: '600',
     color: colors.primary,
+    textAlign: 'center',
   },
   buttonPressed: {
     opacity: 0.92,

--- a/frontend/app/account-settings.tsx
+++ b/frontend/app/account-settings.tsx
@@ -182,7 +182,14 @@ export default function AccountSettingsScreen() {
           return;
         }
 
-        await updateMessageNotificationsEnabled({ enabled: true });
+        try {
+          await updateMessageNotificationsEnabled({ enabled: true });
+        } catch (error) {
+          setMessageNotificationsValue(previousValue);
+          const message =
+            error instanceof Error ? error.message : 'Failed to update notification preference';
+          Alert.alert('Notification Update Failed', message);
+        }
       } else {
         let removePushTokenSucceeded = false;
         let removePushTokenError: unknown = null;
@@ -195,6 +202,16 @@ export default function AccountSettingsScreen() {
 
         try {
           await updateMessageNotificationsEnabled({ enabled: false });
+          if (!removePushTokenSucceeded) {
+            const removeTokenMessage =
+              removePushTokenError instanceof Error
+                ? removePushTokenError.message
+                : 'Failed to remove this device push token.';
+            Alert.alert(
+              'Notification partially disabled',
+              `Your notification preference was saved, but we could not remove this device's push token. You may still receive some notifications.\n\nDetails: ${removeTokenMessage}`
+            );
+          }
         } catch (error) {
           const updatePreferenceMessage =
             error instanceof Error ? error.message : 'Failed to update notification preference';
@@ -220,11 +237,6 @@ export default function AccountSettingsScreen() {
           return;
         }
       }
-    } catch (error) {
-      setMessageNotificationsValue(previousValue);
-      const message =
-        error instanceof Error ? error.message : 'Failed to update notification preference';
-      Alert.alert('Notification Update Failed', message);
     } finally {
       setIsUpdatingMessageNotifications(false);
     }

--- a/frontend/app/account-settings.tsx
+++ b/frontend/app/account-settings.tsx
@@ -1,0 +1,343 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  View,
+} from 'react-native';
+import { useMutation, useQuery } from 'convex/react';
+import { useRouter } from 'expo-router';
+import { api } from 'convex/_generated/api';
+import { useAuth } from '../hooks/useAuth';
+import { requestPermissionAndSyncToken } from '../hooks/usePushNotifications';
+import OpenInAppPrompt from '../components/OpenInAppPrompt';
+import { ScreenState } from '../components/ScreenState';
+import { borderRadius, colors, spacing, typography } from '../theme/tokens';
+
+export default function AccountSettingsScreen() {
+  const router = useRouter();
+  const isWeb = Platform.OS === 'web';
+  const { isAuthenticated, isLoading, signOut } = useAuth();
+  const signOutInProgressRef = useRef(false);
+
+  const [isSigningOut, setIsSigningOut] = useState(false);
+  const [messageNotificationsValue, setMessageNotificationsValue] = useState(true);
+  const [isUpdatingMessageNotifications, setIsUpdatingMessageNotifications] = useState(false);
+
+  const messageNotificationsEnabled = useQuery(
+    api.users.getMessageNotificationsEnabled,
+    isAuthenticated && !isWeb ? {} : 'skip'
+  );
+  const updateMessageNotificationsEnabled = useMutation(
+    api.users.updateMessageNotificationsEnabled
+  );
+  const recordPushToken = useMutation(api.pushNotifications.recordPushToken);
+  const removePushToken = useMutation(api.pushNotifications.removePushToken);
+  const deleteAccount = useMutation(api.users.deleteAccount);
+
+  useEffect(() => {
+    if (!isWeb && !isLoading && !isAuthenticated) {
+      router.replace('/auth/login?returnTo=%2Faccount-settings' as never);
+    }
+  }, [isAuthenticated, isLoading, isWeb, router]);
+
+  useEffect(() => {
+    if (typeof messageNotificationsEnabled === 'boolean') {
+      setMessageNotificationsValue(messageNotificationsEnabled);
+    }
+  }, [messageNotificationsEnabled]);
+
+  const handleSignOut = async () => {
+    if (!isAuthenticated) {
+      router.replace('/auth/login?returnTo=%2Faccount-settings' as never);
+      return;
+    }
+
+    if (signOutInProgressRef.current) {
+      return;
+    }
+
+    try {
+      signOutInProgressRef.current = true;
+      setIsSigningOut(true);
+      await signOut();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to sign out';
+      Alert.alert('Sign Out Failed', message);
+    } finally {
+      signOutInProgressRef.current = false;
+      setIsSigningOut(false);
+    }
+  };
+
+  const handleDeleteAccount = () => {
+    Alert.alert(
+      'Delete account',
+      'Are you sure? This will permanently delete your account and all your data. You can always sign back up later.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete account',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await deleteAccount({});
+            } catch (error) {
+              const message = error instanceof Error ? error.message : 'Failed to delete account';
+              Alert.alert('Delete Account Failed', message);
+              return;
+            }
+
+            try {
+              await signOut();
+            } catch (error) {
+              const details = error instanceof Error ? `\n\nDetails: ${error.message}` : '';
+              Alert.alert(
+                'Account Deleted',
+                `Your account was deleted, but we could not sign you out automatically. Please sign out manually.${details}`
+              );
+            }
+          },
+        },
+      ]
+    );
+  };
+
+  const handleMessageNotificationsToggle = async (value: boolean) => {
+    if (isUpdatingMessageNotifications) return;
+
+    const previousValue = messageNotificationsValue;
+    setMessageNotificationsValue(value);
+    setIsUpdatingMessageNotifications(true);
+
+    try {
+      if (value) {
+        let permissionGranted = false;
+        try {
+          permissionGranted = await requestPermissionAndSyncToken(recordPushToken);
+        } catch (error) {
+          setMessageNotificationsValue(previousValue);
+          const message =
+            error instanceof Error ? error.message : 'Unable to enable notifications right now.';
+          Alert.alert('Notification Update Failed', message);
+          return;
+        }
+
+        if (!permissionGranted) {
+          setMessageNotificationsValue(previousValue);
+          Alert.alert(
+            'Notification Update Failed',
+            'Push permission was not granted. Enable notifications in system settings and try again.'
+          );
+          return;
+        }
+
+        await updateMessageNotificationsEnabled({ enabled: true });
+      } else {
+        let removePushTokenSucceeded = false;
+        let removePushTokenError: unknown = null;
+        try {
+          await removePushToken({});
+          removePushTokenSucceeded = true;
+        } catch (error) {
+          removePushTokenError = error;
+        }
+
+        try {
+          await updateMessageNotificationsEnabled({ enabled: false });
+        } catch (error) {
+          const updatePreferenceMessage =
+            error instanceof Error ? error.message : 'Failed to update notification preference';
+
+          if (removePushTokenSucceeded) {
+            Alert.alert(
+              'Notification partially updated',
+              `This device push token was removed, but we could not save your notification preference.\n\nDetails: ${updatePreferenceMessage}`
+            );
+            return;
+          }
+
+          setMessageNotificationsValue(previousValue);
+          const removeTokenMessage =
+            removePushTokenError instanceof Error
+              ? removePushTokenError.message
+              : 'Failed to remove this device push token.';
+
+          Alert.alert(
+            'Notification Update Failed',
+            `We could not disable notifications.\n\nToken removal: ${removeTokenMessage}\nPreference update: ${updatePreferenceMessage}`
+          );
+          return;
+        }
+      }
+    } catch (error) {
+      setMessageNotificationsValue(previousValue);
+      const message =
+        error instanceof Error ? error.message : 'Failed to update notification preference';
+      Alert.alert('Notification Update Failed', message);
+    } finally {
+      setIsUpdatingMessageNotifications(false);
+    }
+  };
+
+  if (isWeb) {
+    return (
+      <OpenInAppPrompt
+        title="Open account settings in the mobile app"
+        body="Notification preferences, sign out, and account deletion are available in the PolyBuys mobile app."
+        path="/account-settings"
+        buttonLabel="Open in app"
+        secondaryActionLabel="Back to home"
+        onSecondaryAction={() => router.replace('/')}
+      />
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <View style={styles.loadingState}>
+        <ScreenState variant="loading" title="Redirecting to login..." />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentInsetAdjustmentBehavior="automatic"
+      contentContainerStyle={styles.content}
+    >
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Notifications</Text>
+        <View style={styles.notificationRow}>
+          <Text style={styles.notificationLabel}>Message notifications</Text>
+          <Switch
+            value={messageNotificationsValue}
+            onValueChange={(value) => void handleMessageNotificationsToggle(value)}
+            disabled={isUpdatingMessageNotifications || messageNotificationsEnabled === undefined}
+            trackColor={{ false: colors.border, true: colors.primary }}
+            thumbColor={colors.white}
+          />
+        </View>
+        <Text style={styles.notificationHint}>
+          Get notified when someone messages you about a listing.
+        </Text>
+      </View>
+
+      <View style={styles.footer}>
+        <Pressable
+          style={({ pressed }) => [
+            styles.secondaryButton,
+            pressed && styles.buttonPressed,
+            (isSigningOut || isLoading) && styles.buttonDisabled,
+          ]}
+          onPress={() => void handleSignOut()}
+          disabled={isSigningOut || isLoading}
+        >
+          <Text style={styles.secondaryButtonText}>
+            {isSigningOut ? 'Signing out...' : 'Sign out'}
+          </Text>
+        </Pressable>
+        <Pressable
+          style={({ pressed }) => [
+            styles.deleteButton,
+            pressed && styles.buttonPressed,
+            isLoading && styles.buttonDisabled,
+          ]}
+          onPress={handleDeleteAccount}
+          disabled={isLoading}
+        >
+          <Text style={styles.deleteButtonText}>Delete account</Text>
+        </Pressable>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  loadingState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.background,
+    gap: spacing.sm,
+  },
+  content: {
+    width: '100%',
+    maxWidth: 980,
+    alignSelf: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
+    paddingBottom: spacing.xxl,
+    gap: spacing.lg,
+  },
+  section: {
+    backgroundColor: colors.surface,
+    borderRadius: borderRadius.xl,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: spacing.xl,
+    gap: spacing.sm,
+  },
+  sectionTitle: {
+    ...typography.heading,
+    color: colors.textDark,
+  },
+  notificationRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  notificationLabel: {
+    ...typography.body,
+    color: colors.text,
+  },
+  notificationHint: {
+    ...typography.footnote,
+    color: colors.muted,
+  },
+  footer: {
+    marginTop: spacing.md,
+    gap: spacing.md,
+  },
+  deleteButton: {
+    alignSelf: 'flex-start',
+    paddingVertical: spacing.md,
+    paddingHorizontal: 0,
+  },
+  deleteButtonText: {
+    ...typography.subhead,
+    color: colors.destructive,
+    fontWeight: '600',
+  },
+  secondaryButton: {
+    borderWidth: 1,
+    borderColor: colors.primary,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.md,
+    minHeight: 44,
+    justifyContent: 'center',
+    alignSelf: 'flex-start',
+  },
+  secondaryButtonText: {
+    ...typography.subhead,
+    fontWeight: '600',
+    color: colors.primary,
+  },
+  buttonPressed: {
+    opacity: 0.92,
+    transform: [{ scale: 0.99 }],
+  },
+  buttonDisabled: {
+    opacity: 0.7,
+  },
+});

--- a/frontend/app/account-settings.tsx
+++ b/frontend/app/account-settings.tsx
@@ -245,11 +245,13 @@ export default function AccountSettingsScreen() {
         <Pressable
           style={({ pressed }) => [
             styles.deleteButton,
-            pressed && styles.buttonPressed,
+            pressed && styles.deleteButtonPressed,
             isLoading && styles.buttonDisabled,
           ]}
           onPress={handleDeleteAccount}
           disabled={isLoading}
+          accessibilityRole="button"
+          accessibilityLabel="Delete account permanently"
         >
           <Text style={styles.deleteButtonText}>Delete account</Text>
         </Pressable>
@@ -309,9 +311,20 @@ const styles = StyleSheet.create({
     gap: spacing.md,
   },
   deleteButton: {
-    alignSelf: 'flex-start',
+    alignSelf: 'stretch',
+    borderWidth: 2,
+    borderColor: colors.destructive,
+    borderRadius: borderRadius.md,
     paddingVertical: spacing.md,
-    paddingHorizontal: 0,
+    paddingHorizontal: spacing.xl,
+    minHeight: 44,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(179, 38, 30, 0.06)',
+  },
+  deleteButtonPressed: {
+    opacity: 0.92,
+    backgroundColor: 'rgba(179, 38, 30, 0.12)',
   },
   deleteButtonText: {
     ...typography.subhead,

--- a/frontend/app/account-settings.tsx
+++ b/frontend/app/account-settings.tsx
@@ -309,14 +309,15 @@ const styles = StyleSheet.create({
   footer: {
     marginTop: spacing.md,
     gap: spacing.md,
+    alignSelf: 'flex-start',
+    alignItems: 'stretch',
   },
   deleteButton: {
-    alignSelf: 'stretch',
     borderWidth: 2,
     borderColor: colors.destructive,
     borderRadius: borderRadius.md,
-    paddingVertical: spacing.md,
     paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.md,
     minHeight: 44,
     justifyContent: 'center',
     alignItems: 'center',
@@ -339,7 +340,7 @@ const styles = StyleSheet.create({
     paddingVertical: spacing.md,
     minHeight: 44,
     justifyContent: 'center',
-    alignSelf: 'flex-start',
+    alignItems: 'center',
   },
   secondaryButtonText: {
     ...typography.subhead,

--- a/frontend/app/listings/[id].tsx
+++ b/frontend/app/listings/[id].tsx
@@ -134,7 +134,7 @@ export default function ListingDetailScreen() {
     router.push({
       pathname: '/conversations/new',
       params: { listingId: String(listing._id) },
-    });
+    } as never);
   };
 
   const onSavePress = async () => {
@@ -496,7 +496,7 @@ export default function ListingDetailScreen() {
         {sellerProfile && (
           <Pressable
             style={styles.sellerBlock}
-            onPress={() => router.push(`/profile/${encodeURIComponent(listing.sellerId)}`)}
+            onPress={() => router.push(`/profile/${encodeURIComponent(listing.sellerId)}` as never)}
             accessibilityLabel={`View ${sellerProfile.name}'s profile`}
             accessibilityRole="button"
           >

--- a/frontend/ios/PolyBuys.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/frontend/ios/PolyBuys.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/frontend/ios/PolyBuys.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/frontend/ios/PolyBuys.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
- Add /account-settings stack screen with message notifications, sign out, and delete account
- Profile tab shows a Settings row (and account settings on incomplete profile) linking there
- Web: OpenInAppPrompt for account settings deep link, consistent with profile tab
- Fix typed-route pushes with as never where the generated routes lag

Made-with: Cursor

## Linked Issues

Closes #77
Linear: POLY-56 

## Summary

Briefly explain the change and why.

## How to Test

Steps to verify locally:

- `npm run lint`
- `npm run typecheck`
- `npm test`
- Manual flow:
  1. `npm run dev:backend` (in terminal A)
  2. `npm run dev` (in terminal B)
  3. Verify the change: <describe expected behavior/screens>

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Lint/tests pass locally (`npm run lint`)
- [ ] Docs updated (README/ADR/changelog if needed)
- [ ] Follows conventional commit format
- [ ] No merge conflicts with `dev`

## Screenshots / Demos

(if UI or visible behavior - attach images, videos, or GIFs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Account Settings screen: manage message notifications, view/unblock blocked users, sign out, and delete your account.

* **Refactoring**
  * Simplified the main Settings entry to route into the new Account Settings flow; removed in-page notification and account management UI.
  * Updated navigation call sites for typing consistency.

* **Chores**
  * Added iOS workspace metadata files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->