### PR TITLE
feat(frontend): dismissible flash banner and safe placement

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -8,6 +8,7 @@ import { StatusBar } from 'expo-status-bar';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { Platform, useColorScheme } from 'react-native';
+import { FlashProvider } from '../contexts/FlashContext';
 import { usePushNotifications } from '../hooks/usePushNotifications';
 
 const allowSentryPii = process.env.EXPO_PUBLIC_ENABLE_SENTRY_PII === 'true';
@@ -51,56 +52,58 @@ function RootLayout() {
     <SafeAreaProvider>
       <ConvexAuthProvider client={convex} storage={storage}>
         <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-          <PushNotificationsBootstrap />
-          <StatusBar style="auto" />
-          <Stack
-            screenOptions={{
-              headerBackButtonDisplayMode: 'minimal',
-            }}
-          >
-            <Stack.Screen name="(tabs)" options={{ headerShown: false, title: 'Home' }} />
-            <Stack.Screen
-              name="listings/[id]"
-              options={{ title: 'Listing Details', headerBackTitle: 'Back' }}
-            />
-            <Stack.Screen
-              name="listings/new"
-              options={{ title: 'Create Listing', headerBackTitle: 'Back' }}
-            />
-            <Stack.Screen
-              name="listings/[id]/edit"
-              options={{ title: 'Edit Listing', headerBackTitle: 'Back' }}
-            />
-            <Stack.Screen
-              name="messages/[id]"
-              options={{ title: 'Messages', headerBackTitle: 'Back' }}
-            />
-            <Stack.Screen
-              name="conversations/[id]"
-              options={{ title: 'Conversation', headerBackTitle: 'Inbox' }}
-            />
-            <Stack.Screen
-              name="auth/login"
-              options={{
-                title: 'Sign In',
-                headerBackTitle: 'Back',
-                headerShown: Platform.OS !== 'web',
+          <FlashProvider>
+            <PushNotificationsBootstrap />
+            <StatusBar style="auto" />
+            <Stack
+              screenOptions={{
+                headerBackButtonDisplayMode: 'minimal',
               }}
-            />
-            <Stack.Screen
-              name="account-settings"
-              options={{ title: 'Settings', headerBackTitle: 'Profile' }}
-            />
-            <Stack.Screen
-              name="profile/edit"
-              options={{ title: 'Edit Profile', headerBackTitle: 'Profile' }}
-            />
-            <Stack.Screen
-              name="profile/[userId]"
-              options={{ title: 'Profile', headerBackTitle: 'Back' }}
-            />
-            <Stack.Screen name="l/[id]" options={{ headerShown: false }} />
-          </Stack>
+            >
+              <Stack.Screen name="(tabs)" options={{ headerShown: false, title: 'Home' }} />
+              <Stack.Screen
+                name="listings/[id]"
+                options={{ title: 'Listing Details', headerBackTitle: 'Back' }}
+              />
+              <Stack.Screen
+                name="listings/new"
+                options={{ title: 'Create Listing', headerBackTitle: 'Back' }}
+              />
+              <Stack.Screen
+                name="listings/[id]/edit"
+                options={{ title: 'Edit Listing', headerBackTitle: 'Back' }}
+              />
+              <Stack.Screen
+                name="messages/[id]"
+                options={{ title: 'Messages', headerBackTitle: 'Back' }}
+              />
+              <Stack.Screen
+                name="conversations/[id]"
+                options={{ title: 'Conversation', headerBackTitle: 'Inbox' }}
+              />
+              <Stack.Screen
+                name="auth/login"
+                options={{
+                  title: 'Sign In',
+                  headerBackTitle: 'Back',
+                  headerShown: Platform.OS !== 'web',
+                }}
+              />
+              <Stack.Screen
+                name="account-settings"
+                options={{ title: 'Settings', headerBackTitle: 'Profile' }}
+              />
+              <Stack.Screen
+                name="profile/edit"
+                options={{ title: 'Edit Profile', headerBackTitle: 'Profile' }}
+              />
+              <Stack.Screen
+                name="profile/[userId]"
+                options={{ title: 'Profile', headerBackTitle: 'Back' }}
+              />
+              <Stack.Screen name="l/[id]" options={{ headerShown: false }} />
+            </Stack>
+          </FlashProvider>
         </ThemeProvider>
       </ConvexAuthProvider>
     </SafeAreaProvider>

--- a/frontend/app/listings/[id].tsx
+++ b/frontend/app/listings/[id].tsx
@@ -37,6 +37,7 @@ import { Chip } from '../../components/ui';
 import ImageLightbox from '../../components/ImageLightbox';
 
 import { APP_STORE_URL } from '../../constants/app';
+import { REPORT_SUBMITTED_MESSAGE } from '../../constants/feedbackMessages';
 
 type FeedTabHref = '/' | '/search' | '/settings';
 const DEFAULT_APP_ORIGIN = 'https://polybuys.com';
@@ -564,9 +565,7 @@ export default function ListingDetailScreen() {
           onClose={() => setReportOpen(false)}
           targetId={String(listing._id)}
           targetType="listing"
-          onReportSuccess={() =>
-            setFlash('Report submitted. Thanks for helping keep PolyBuys safe.')
-          }
+          onReportSuccess={() => setFlash(REPORT_SUBMITTED_MESSAGE)}
         />
       </Animated.View>
 

--- a/frontend/app/listings/[id].tsx
+++ b/frontend/app/listings/[id].tsx
@@ -23,6 +23,7 @@ import Constants from 'expo-constants';
 import { useMutation, useQuery } from 'convex/react';
 import { api } from 'convex/_generated/api';
 import { Id } from 'convex/_generated/dataModel';
+import { useFlash } from '../../contexts/FlashContext';
 import { useAuth } from '../../hooks/useAuth';
 import HiddenBanner from '../../components/HiddenBanner';
 import ListingUnavailable from '../../components/ListingUnavailable';
@@ -68,6 +69,7 @@ export default function ListingDetailScreen() {
   const { id } = useLocalSearchParams<{ id?: string | string[] }>();
   const listingId = typeof id === 'string' && id.trim().length > 0 ? id : null;
   const router = useRouter();
+  const { setFlash } = useFlash();
   const { isAuthenticated } = useAuth();
   const entranceStyle = useEntranceAnimation();
   const appOrigin = getAppOrigin();
@@ -194,6 +196,7 @@ export default function ListingDetailScreen() {
     try {
       setMarkingSold(true);
       await updateListingStatus({ id: listing._id, status: 'sold' });
+      setFlash('Listing marked as sold.');
     } catch (error) {
       const message =
         error instanceof Error && error.message
@@ -561,6 +564,9 @@ export default function ListingDetailScreen() {
           onClose={() => setReportOpen(false)}
           targetId={String(listing._id)}
           targetType="listing"
+          onReportSuccess={() =>
+            setFlash('Report submitted. Thanks for helping keep PolyBuys safe.')
+          }
         />
       </Animated.View>
 

--- a/frontend/app/listings/[id]/edit.tsx
+++ b/frontend/app/listings/[id]/edit.tsx
@@ -19,6 +19,7 @@ import type { Id } from 'convex/_generated/dataModel';
 import ImageUploader from '@/components/ImageUploader';
 import ListingUnavailable from '../../../components/ListingUnavailable';
 import TagInput from '../../../components/TagInput';
+import { useFlash } from '../../../contexts/FlashContext';
 import { useEntranceAnimation } from '../../../hooks/useEntranceAnimation';
 import { borderRadius, colors, spacing, typography } from '../../../theme/tokens';
 
@@ -53,6 +54,7 @@ function getListingActionError(error: unknown, fallbackTitle: string) {
 
 export default function EditListingScreen() {
   const router = useRouter();
+  const { setFlash } = useFlash();
   const { id } = useLocalSearchParams<{ id?: string | string[] }>();
   const listingId = typeof id === 'string' && id.trim().length > 0 ? id : null;
   const listing = useQuery(
@@ -149,7 +151,8 @@ export default function EditListingScreen() {
         );
         return;
       }
-      showAlert('Success', 'Listing updated.', () => router.back());
+      setFlash('Listing updated.');
+      router.back();
     } catch (error) {
       const actionError = getListingActionError(error, 'Update failed');
       showAlert(actionError.title, actionError.message);

--- a/frontend/app/listings/new.tsx
+++ b/frontend/app/listings/new.tsx
@@ -17,6 +17,7 @@ import { useRouter } from 'expo-router';
 import { api } from 'convex/_generated/api';
 import ImageUploader from '@/components/ImageUploader';
 import TagInput from '../../components/TagInput';
+import { useFlash } from '../../contexts/FlashContext';
 import { useAuth } from '../../hooks/useAuth';
 import { useEntranceAnimation } from '../../hooks/useEntranceAnimation';
 import { colors, typography, borderRadius, spacing } from '../../theme/tokens';
@@ -61,6 +62,7 @@ function getListingActionError(error: unknown, fallbackTitle: string) {
 
 export default function NewListingScreen() {
   const router = useRouter();
+  const { setFlash } = useFlash();
   const createListing = useAction(api.listings.createListing);
   const { isAuthenticated, isSessionLoading } = useAuth();
   const entranceStyle = useEntranceAnimation();
@@ -144,7 +146,8 @@ export default function NewListingScreen() {
         images,
         tags,
       });
-      showAlert('Success', 'Listing created.', () => router.replace('/'));
+      setFlash('Listing created.');
+      router.replace('/');
     } catch (error) {
       const actionError = getListingActionError(error, 'Create failed');
       showAlert(actionError.title, actionError.message);

--- a/frontend/app/profile/[userId].tsx
+++ b/frontend/app/profile/[userId].tsx
@@ -18,6 +18,7 @@ import { useResolvedImageUrls } from '../../hooks/useResolvedImageUrls';
 import ListingCard from '../../components/ListingCard';
 import { ReportModal } from '../../components/ReportModal';
 import { ScreenState } from '../../components/ScreenState';
+import { REPORT_SUBMITTED_MESSAGE } from '../../constants/feedbackMessages';
 import { colors, typography, spacing, borderRadius } from '../../theme/tokens';
 
 function yearToOrdinal(gradYear: number): string {
@@ -140,7 +141,7 @@ export default function PublicProfileScreen() {
         onClose={() => setReportOpen(false)}
         targetId={profile._id}
         targetType="profile"
-        onReportSuccess={() => setFlash('Report submitted. Thanks for helping keep PolyBuys safe.')}
+        onReportSuccess={() => setFlash(REPORT_SUBMITTED_MESSAGE)}
       />
 
       <Text style={styles.sectionTitle}>Listings</Text>

--- a/frontend/app/profile/[userId].tsx
+++ b/frontend/app/profile/[userId].tsx
@@ -12,6 +12,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useQuery } from 'convex/react';
 import { api } from 'convex/_generated/api';
 import type { Doc } from 'convex/_generated/dataModel';
+import { useFlash } from '../../contexts/FlashContext';
 import { useAuth } from '../../hooks/useAuth';
 import { useResolvedImageUrls } from '../../hooks/useResolvedImageUrls';
 import ListingCard from '../../components/ListingCard';
@@ -30,6 +31,7 @@ function yearToOrdinal(gradYear: number): string {
 export default function PublicProfileScreen() {
   const { userId: rawUserId } = useLocalSearchParams<{ userId?: string }>();
   const router = useRouter();
+  const { setFlash } = useFlash();
   const { width } = useWindowDimensions();
   const { user, isAuthenticated } = useAuth();
   const [reportOpen, setReportOpen] = useState(false);
@@ -138,6 +140,7 @@ export default function PublicProfileScreen() {
         onClose={() => setReportOpen(false)}
         targetId={profile._id}
         targetType="profile"
+        onReportSuccess={() => setFlash('Report submitted. Thanks for helping keep PolyBuys safe.')}
       />
 
       <Text style={styles.sectionTitle}>Listings</Text>

--- a/frontend/components/ReportModal.tsx
+++ b/frontend/components/ReportModal.tsx
@@ -11,6 +11,8 @@ type ReportModalProps = {
   onClose: () => void;
   targetId: string;
   targetType: 'listing' | 'profile';
+  /** When set, success uses this instead of a blocking alert (e.g. in-app flash banner). */
+  onReportSuccess?: () => void;
 };
 
 const REASONS: { value: ReportReason; label: string; desc: string }[] = [
@@ -21,7 +23,13 @@ const REASONS: { value: ReportReason; label: string; desc: string }[] = [
 
 const MAX_NOTES = 500;
 
-export function ReportModal({ isVisible, onClose, targetId, targetType }: ReportModalProps) {
+export function ReportModal({
+  isVisible,
+  onClose,
+  targetId,
+  targetType,
+  onReportSuccess,
+}: ReportModalProps) {
   const createReport = useMutation(api.reports.createReport);
   const [reason, setReason] = useState<ReportReason | null>(null);
   const [notes, setNotes] = useState('');
@@ -48,7 +56,11 @@ export function ReportModal({ isVisible, onClose, targetId, targetType }: Report
         reason,
         notes: notes.trim() ? notes.trim() : undefined,
       });
-      Alert.alert('Report submitted', 'Thanks for helping keep PolyBuys safe.');
+      if (onReportSuccess) {
+        onReportSuccess();
+      } else {
+        Alert.alert('Report submitted', 'Thanks for helping keep PolyBuys safe.');
+      }
       handleClose();
     } catch (err) {
       const msg = String((err as Error)?.message ?? 'Unable to submit report right now.');

--- a/frontend/components/ReportModal.tsx
+++ b/frontend/components/ReportModal.tsx
@@ -3,6 +3,10 @@ import { Alert, Modal, Pressable, StyleSheet, Text, TextInput, View } from 'reac
 import { colors } from '../theme/tokens';
 import { useMutation } from 'convex/react';
 import { api } from 'convex/_generated/api';
+import {
+  REPORT_SUBMITTED_ALERT_BODY,
+  REPORT_SUBMITTED_ALERT_TITLE,
+} from '../constants/feedbackMessages';
 
 type ReportReason = 'scam' | 'inappropriate' | 'spam';
 
@@ -59,7 +63,7 @@ export function ReportModal({
       if (onReportSuccess) {
         onReportSuccess();
       } else {
-        Alert.alert('Report submitted', 'Thanks for helping keep PolyBuys safe.');
+        Alert.alert(REPORT_SUBMITTED_ALERT_TITLE, REPORT_SUBMITTED_ALERT_BODY);
       }
       handleClose();
     } catch (err) {

--- a/frontend/constants/feedbackMessages.ts
+++ b/frontend/constants/feedbackMessages.ts
@@ -1,0 +1,7 @@
+/** User-facing copy shared across flash banners, alerts, and modals. */
+
+export const REPORT_SUBMITTED_ALERT_TITLE = 'Report submitted';
+export const REPORT_SUBMITTED_ALERT_BODY = 'Thanks for helping keep PolyBuys safe.';
+
+/** Full sentence for in-app flash after a report succeeds. */
+export const REPORT_SUBMITTED_MESSAGE = `${REPORT_SUBMITTED_ALERT_TITLE}. ${REPORT_SUBMITTED_ALERT_BODY}`;

--- a/frontend/contexts/FlashContext.tsx
+++ b/frontend/contexts/FlashContext.tsx
@@ -17,7 +17,8 @@ type FlashContextValue = {
 const FlashContext = createContext<FlashContextValue | null>(null);
 
 const FLASH_DURATION_MS = 2000;
-const FLASH_DURATION_REDUCED_MS = 900;
+/** Longer than default so reduced-motion users have enough time to read the message. */
+const FLASH_DURATION_REDUCED_MS = 4000;
 
 /** Space above bottom home indicator / tab bar so the banner does not cover primary nav. */
 function bottomOffsetForPlatform(): number {

--- a/frontend/contexts/FlashContext.tsx
+++ b/frontend/contexts/FlashContext.tsx
@@ -107,7 +107,7 @@ export function FlashProvider({ children }: { children: React.ReactNode }) {
             accessibilityElementsHidden={false}
           >
             <Pressable
-              style={({ pressed }) => [styles.banner, pressed && styles.bannerPressed]}
+              style={styles.banner}
               onPress={clearFlash}
               accessibilityRole="alert"
               accessibilityLiveRegion="polite"
@@ -115,6 +115,7 @@ export function FlashProvider({ children }: { children: React.ReactNode }) {
               accessibilityHint="Double tap to dismiss"
               accessibilityLabel={message}
               pointerEvents="auto"
+              android_ripple={{ color: 'rgba(255,255,255,0.14)', borderless: false }}
             >
               <Text style={styles.text}>{message}</Text>
               <View style={styles.dismissRow}>
@@ -133,12 +134,12 @@ const styles = StyleSheet.create({
   wrapper: {
     flex: 1,
   },
+  // No elevation here — Android would composite oddly with a translucent child Pressable.
   bannerSlot: {
     position: 'absolute',
     left: 16,
     right: 16,
     zIndex: 9999,
-    elevation: 8,
     alignItems: 'stretch',
   },
   banner: {
@@ -154,13 +155,23 @@ const styles = StyleSheet.create({
     maxWidth: 520,
     alignSelf: 'center',
     width: '100%',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 3 },
-    shadowOpacity: 0.14,
-    shadowRadius: 10,
-  },
-  bannerPressed: {
-    opacity: 0.94,
+    ...Platform.select({
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 3 },
+        shadowOpacity: 0.14,
+        shadowRadius: 10,
+      },
+      android: {
+        elevation: 6,
+      },
+      default: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 3 },
+        shadowOpacity: 0.14,
+        shadowRadius: 10,
+      },
+    }),
   },
   text: {
     fontSize: 14,

--- a/frontend/contexts/FlashContext.tsx
+++ b/frontend/contexts/FlashContext.tsx
@@ -22,12 +22,12 @@ const FLASH_DURATION_REDUCED_MS = 900;
 /** Space above bottom home indicator / tab bar so the banner does not cover primary nav. */
 function bottomOffsetForPlatform(): number {
   if (Platform.OS === 'web') {
-    return 16;
+    return 28;
   }
   if (Platform.OS === 'ios') {
-    return 52;
+    return 64;
   }
-  return 56;
+  return 68;
 }
 
 export function useFlash() {
@@ -142,22 +142,25 @@ const styles = StyleSheet.create({
     alignItems: 'stretch',
   },
   banner: {
-    borderRadius: 12,
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    backgroundColor: '#166534',
+    borderRadius: 14,
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    // Solid green read with a hint of transparency so content behind peeks through slightly
+    backgroundColor: 'rgba(22, 101, 52, 0.88)',
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: 'rgba(255, 255, 255, 0.22)',
     alignItems: 'center',
     justifyContent: 'center',
-    maxWidth: 560,
+    maxWidth: 520,
     alignSelf: 'center',
     width: '100%',
     shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.2,
-    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.14,
+    shadowRadius: 10,
   },
   bannerPressed: {
-    opacity: 0.92,
+    opacity: 0.94,
   },
   text: {
     fontSize: 14,

--- a/frontend/contexts/FlashContext.tsx
+++ b/frontend/contexts/FlashContext.tsx
@@ -1,0 +1,186 @@
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import {
+  AccessibilityInfo,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  type AccessibilityValue,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+type FlashContextValue = {
+  setFlash: (message: string) => void;
+};
+
+const FlashContext = createContext<FlashContextValue | null>(null);
+
+const FLASH_DURATION_MS = 2000;
+const FLASH_DURATION_REDUCED_MS = 900;
+
+/** Space above bottom home indicator / tab bar so the banner does not cover primary nav. */
+function bottomOffsetForPlatform(): number {
+  if (Platform.OS === 'web') {
+    return 16;
+  }
+  if (Platform.OS === 'ios') {
+    return 52;
+  }
+  return 56;
+}
+
+export function useFlash() {
+  const ctx = useContext(FlashContext);
+  if (!ctx) {
+    throw new Error('useFlash must be used within FlashProvider');
+  }
+  return ctx;
+}
+
+export function FlashProvider({ children }: { children: React.ReactNode }) {
+  const insets = useSafeAreaInsets();
+  const [message, setMessage] = useState<string | null>(null);
+  const [reduceMotion, setReduceMotion] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearFlash = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    setMessage(null);
+  }, []);
+
+  const setFlash = useCallback(
+    (msg: string) => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+      setMessage(msg);
+      const ms = reduceMotion ? FLASH_DURATION_REDUCED_MS : FLASH_DURATION_MS;
+      timeoutRef.current = setTimeout(() => {
+        setMessage(null);
+        timeoutRef.current = null;
+      }, ms);
+    },
+    [reduceMotion]
+  );
+
+  useEffect(() => {
+    let subscription: { remove?: () => void } | undefined;
+    AccessibilityInfo.isReduceMotionEnabled().then(setReduceMotion);
+    if (typeof AccessibilityInfo.addEventListener === 'function') {
+      subscription = AccessibilityInfo.addEventListener('reduceMotionChanged', setReduceMotion);
+    }
+    return () => {
+      subscription?.remove?.();
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const bottom = insets.bottom + bottomOffsetForPlatform();
+
+  const accessibilityValue: AccessibilityValue = {
+    min: 0,
+    max: 100,
+    now: message ? 100 : 0,
+    text: message ?? undefined,
+  };
+
+  return (
+    <FlashContext.Provider value={{ setFlash }}>
+      <View style={styles.wrapper} pointerEvents="box-none">
+        {children}
+        {message ? (
+          <View
+            style={[styles.bannerSlot, { bottom }]}
+            pointerEvents="box-none"
+            accessibilityElementsHidden={false}
+          >
+            <Pressable
+              style={({ pressed }) => [styles.banner, pressed && styles.bannerPressed]}
+              onPress={clearFlash}
+              accessibilityRole="alert"
+              accessibilityLiveRegion="polite"
+              accessibilityValue={accessibilityValue}
+              accessibilityHint="Double tap to dismiss"
+              accessibilityLabel={message}
+              pointerEvents="auto"
+            >
+              <Text style={styles.text}>{message}</Text>
+              <View style={styles.dismissRow}>
+                <Text style={styles.dismissHint}>Tap anywhere to dismiss</Text>
+                <Text style={styles.dismissLinkText}>Dismiss</Text>
+              </View>
+            </Pressable>
+          </View>
+        ) : null}
+      </View>
+    </FlashContext.Provider>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    flex: 1,
+  },
+  bannerSlot: {
+    position: 'absolute',
+    left: 16,
+    right: 16,
+    zIndex: 9999,
+    elevation: 8,
+    alignItems: 'stretch',
+  },
+  banner: {
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    backgroundColor: '#166534',
+    alignItems: 'center',
+    justifyContent: 'center',
+    maxWidth: 560,
+    alignSelf: 'center',
+    width: '100%',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.2,
+    shadowRadius: 6,
+  },
+  bannerPressed: {
+    opacity: 0.92,
+  },
+  text: {
+    fontSize: 14,
+    color: '#fff',
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  dismissRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    marginTop: 6,
+    flexWrap: 'wrap',
+  },
+  dismissHint: {
+    fontSize: 12,
+    color: 'rgba(255,255,255,0.88)',
+    fontWeight: '500',
+  },
+  dismissLinkText: {
+    fontSize: 12,
+    color: '#fff',
+    fontWeight: '700',
+  },
+});


### PR DESCRIPTION
- Add FlashProvider with bottom-inset positioning above tab/home area
- pointerEvents box-none/auto so banner receives taps; tap or Dismiss clears
- Shorter auto-dismiss when reduce motion is enabled
- Wire create/edit listing, mark sold, and report success to setFlash
- ReportModal optional onReportSuccess for non-blocking confirmation

Made-with: Cursor

## Linked Issues

Closes #79
Linear: POLY-56 (e.g., POLY-123)

## Summary

Briefly explain the change and why.

## How to Test

Steps to verify locally:

- `npm run lint`
- `npm run typecheck`
- `npm test`
- Manual flow:
  1. `npm run dev:backend` (in terminal A)
  2. `npm run dev` (in terminal B)
  3. Verify the change: <describe expected behavior/screens>

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Lint/tests pass locally (`npm run lint`)
- [ ] Docs updated (README/ADR/changelog if needed)
- [ ] Follows conventional commit format
- [ ] No merge conflicts with `dev`

## Screenshots / Demos

(if UI or visible behavior - attach images, videos, or GIFs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced flash notification system for displaying action confirmations as non-blocking banners
  * Listing creation, updates, and status changes now trigger auto-dismissing success notifications
  * Report submissions now display success messages as flash notifications
  * Added accessibility features including reduced motion support and live region announcements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->