### PR TITLE
Feat/poly 76 listing card polish

### DIFF
--- a/frontend/components/ListingCard.tsx
+++ b/frontend/components/ListingCard.tsx
@@ -20,6 +20,20 @@ function markAsAnimated(id: string): void {
   animatedListingIds.set(id, undefined);
 }
 
+function formatConditionLabel(condition?: 'new' | 'used' | 'refurbished'): string | null {
+  if (!condition) return null;
+  switch (condition) {
+    case 'new':
+      return 'New';
+    case 'used':
+      return 'Used';
+    case 'refurbished':
+      return 'Refurbished';
+    default:
+      return null;
+  }
+}
+
 export type ListingCardBadge = 'sold' | 'unavailable';
 
 export type ListingCardDensity = 'default' | 'home';
@@ -32,6 +46,7 @@ interface ListingCardProps {
     price: number;
     description: string;
     images?: string[];
+    condition?: 'new' | 'used' | 'refurbished';
   };
   index?: number;
   isSaved?: boolean;
@@ -111,6 +126,8 @@ export default function ListingCard({
   const isHomeDensity = density === 'home';
   const isFlatShell = shellStyle === 'flat';
   const isWeb = Platform.OS === 'web';
+  const conditionLabel = formatConditionLabel(listing.condition);
+  const titleLines = isHomeDensity ? 2 : 3;
 
   return (
     <Animated.View
@@ -133,7 +150,7 @@ export default function ListingCard({
           }
           onHoverIn={() => setIsHovered(true)}
           onHoverOut={() => setIsHovered(false)}
-          accessibilityLabel={`${listing.title}, $${formatPrice(listing.price)}${badgeToShow ? `, ${badgeToShow === 'sold' ? 'Sold' : 'Unavailable'}` : ''}`}
+          accessibilityLabel={`${listing.title}, $${formatPrice(listing.price)}${conditionLabel ? `, ${conditionLabel}` : ''}${badgeToShow ? `, ${badgeToShow === 'sold' ? 'Sold' : 'Unavailable'}` : ''}`}
           accessibilityRole="button"
         >
           <View
@@ -163,13 +180,22 @@ export default function ListingCard({
               </View>
             )}
           </View>
-          <View style={[styles.titlePriceRow, isHomeDensity && styles.titlePriceRowHome]}>
+          <View style={[styles.cardDetails, isHomeDensity && styles.cardDetailsHome]}>
             <Text
               style={[styles.listingTitle, isHomeDensity && styles.listingTitleHome]}
-              numberOfLines={1}
+              numberOfLines={titleLines}
+              ellipsizeMode="tail"
             >
               {listing.title}
             </Text>
+            {conditionLabel ? (
+              <Text
+                style={[styles.listingCondition, isHomeDensity && styles.listingConditionHome]}
+                numberOfLines={1}
+              >
+                {conditionLabel}
+              </Text>
+            ) : null}
             <Text
               style={[styles.listingPrice, isHomeDensity && styles.listingPriceHome]}
               numberOfLines={1}
@@ -205,16 +231,18 @@ const styles = StyleSheet.create({
     minWidth: 0,
   },
   listingCardWrapperHome: {
-    marginBottom: 6,
+    marginBottom: spacing.sm,
   },
   cardContainer: {
     position: 'relative',
   },
   listingCard: {
-    borderRadius: borderRadius.sm,
+    borderRadius: borderRadius.md,
     backgroundColor: colors.surface,
     overflow: 'hidden',
-    boxShadow: '0 10px 24px rgba(21, 71, 52, 0.08)',
+    borderWidth: 1,
+    borderColor: colors.border,
+    boxShadow: '0 8px 20px rgba(21, 71, 52, 0.07)',
   },
   listingCardFlat: {
     backgroundColor: 'transparent',
@@ -291,44 +319,54 @@ const styles = StyleSheet.create({
     ...typography.footnote,
     color: colors.text,
   },
-  titlePriceRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: spacing.sm,
-    paddingHorizontal: 0,
-    paddingTop: spacing.xs,
-    paddingBottom: spacing.sm,
-  },
-  titlePriceRowHome: {
-    paddingHorizontal: 0,
+  cardDetails: {
+    paddingHorizontal: spacing.md,
     paddingTop: spacing.sm,
     paddingBottom: spacing.md,
+    gap: spacing.xs,
+  },
+  cardDetailsHome: {
+    paddingHorizontal: spacing.sm + 2,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.md,
+    gap: 2,
   },
   listingTitle: {
-    ...typography.body,
-    fontSize: 14,
-    color: colors.primary,
-    flex: 1,
-    minWidth: 0,
+    ...typography.subhead,
+    fontSize: 16,
+    fontWeight: '600',
+    lineHeight: 21,
+    color: colors.textDark,
   },
   listingTitleHome: {
-    ...typography.subhead,
-    fontSize: 13,
+    fontSize: 15,
+    lineHeight: 20,
     fontWeight: '600',
+  },
+  listingCondition: {
+    ...typography.footnote,
+    color: colors.gray,
+    fontWeight: '500',
+    marginTop: 2,
+  },
+  listingConditionHome: {
+    fontSize: 12,
+    marginTop: 0,
   },
   listingPrice: {
     ...typography.title2,
-    fontSize: 13,
+    fontSize: 18,
+    fontWeight: '700',
     color: colors.accent,
-    flexShrink: 0,
+    marginTop: spacing.xs,
   },
   listingPriceHome: {
-    fontSize: 12,
+    fontSize: 17,
+    marginTop: spacing.xs,
   },
   footer: {
     marginTop: spacing.sm,
-    paddingHorizontal: spacing.sm,
+    paddingHorizontal: spacing.md,
     paddingBottom: spacing.xs,
   },
 });

--- a/frontend/components/ListingCard.tsx
+++ b/frontend/components/ListingCard.tsx
@@ -397,6 +397,7 @@ const styles = StyleSheet.create({
   descBlock: {
     marginTop: 2,
     gap: 2,
+    overflow: 'hidden',
   },
   descBlockHome: {
     marginTop: 0,

--- a/frontend/components/ListingCard.tsx
+++ b/frontend/components/ListingCard.tsx
@@ -21,8 +21,7 @@ function markAsAnimated(id: string): void {
   animatedListingIds.set(id, undefined);
 }
 
-function formatConditionLabel(condition?: 'new' | 'used' | 'refurbished'): string | null {
-  if (!condition) return null;
+function formatConditionLabel(condition: 'new' | 'used' | 'refurbished'): string {
   switch (condition) {
     case 'new':
       return 'New';
@@ -30,8 +29,6 @@ function formatConditionLabel(condition?: 'new' | 'used' | 'refurbished'): strin
       return 'Used';
     case 'refurbished':
       return 'Refurbished';
-    default:
-      return null;
   }
 }
 
@@ -47,7 +44,7 @@ interface ListingCardProps {
     price: number;
     description: string;
     images?: string[];
-    condition?: 'new' | 'used' | 'refurbished';
+    condition: 'new' | 'used' | 'refurbished';
   };
   index?: number;
   isSaved?: boolean;
@@ -147,6 +144,16 @@ export default function ListingCard({
     return `${raw.slice(0, 157)}…`;
   }, [descriptionPreview]);
 
+  const accessibilityLabel = useMemo(() => {
+    const parts = [
+      `${listing.title}, $${formatPrice(listing.price)}`,
+      conditionLabel,
+      accessibilityDescriptionHint,
+      badgeToShow === 'sold' ? 'Sold' : badgeToShow === 'unavailable' ? 'Unavailable' : null,
+    ].filter(Boolean) as string[];
+    return parts.join(', ');
+  }, [listing.title, listing.price, conditionLabel, accessibilityDescriptionHint, badgeToShow]);
+
   return (
     <Animated.View
       style={[
@@ -168,7 +175,7 @@ export default function ListingCard({
           }
           onHoverIn={() => setIsHovered(true)}
           onHoverOut={() => setIsHovered(false)}
-          accessibilityLabel={`${listing.title}, $${formatPrice(listing.price)}${conditionLabel ? `, ${conditionLabel}` : ''}${accessibilityDescriptionHint ? `, ${accessibilityDescriptionHint}` : ''}${badgeToShow ? `, ${badgeToShow === 'sold' ? 'Sold' : 'Unavailable'}` : ''}`}
+          accessibilityLabel={accessibilityLabel}
           accessibilityRole="button"
         >
           <View
@@ -206,14 +213,12 @@ export default function ListingCard({
             >
               {listing.title}
             </Text>
-            {conditionLabel ? (
-              <Text
-                style={[styles.listingCondition, isHomeDensity && styles.listingConditionHome]}
-                numberOfLines={1}
-              >
-                {conditionLabel}
-              </Text>
-            ) : null}
+            <Text
+              style={[styles.listingCondition, isHomeDensity && styles.listingConditionHome]}
+              numberOfLines={1}
+            >
+              {conditionLabel}
+            </Text>
             {descriptionPreview.kind === 'bullets' ? (
               <View style={[styles.descBlock, isHomeDensity && styles.descBlockHome]}>
                 {descriptionPreview.items.map((line, i) => (
@@ -367,7 +372,7 @@ const styles = StyleSheet.create({
     gap: spacing.xs,
   },
   cardDetailsHome: {
-    paddingHorizontal: spacing.sm + 2,
+    paddingHorizontal: spacing.smPlus,
     paddingTop: spacing.sm,
     paddingBottom: spacing.md,
     gap: 2,

--- a/frontend/components/ListingCard.tsx
+++ b/frontend/components/ListingCard.tsx
@@ -34,6 +34,58 @@ function formatConditionLabel(condition?: 'new' | 'used' | 'refurbished'): strin
   }
 }
 
+const DESC_BULLET_MAX = 2;
+/** Per bullet — keeps cards scannable; ellipsis added in UI via numberOfLines. */
+const DESC_BULLET_MAX_CHARS = 78;
+const DESC_LINE_LEADING_LIST = /^\s*[-•*]\s+/;
+
+function normalizeDescriptionWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+type DescriptionPreview =
+  | { kind: 'none' }
+  | { kind: 'plain'; text: string }
+  | { kind: 'bullets'; items: string[] };
+
+/** Short preview for the card: bullets when the seller used line breaks / list markers; else 2-line snippet. */
+function buildDescriptionPreview(raw: string): DescriptionPreview {
+  const trimmed = raw?.trim() ?? '';
+  if (!trimmed) {
+    return { kind: 'none' };
+  }
+
+  const lines = trimmed
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  const looksLikeList =
+    lines.length >= 2 &&
+    lines.length <= 8 &&
+    lines.every((line) => line.length <= 220) &&
+    (lines.some((line) => DESC_LINE_LEADING_LIST.test(line)) ||
+      lines.every((line) => line.length <= 140));
+
+  if (looksLikeList) {
+    const items = lines.slice(0, DESC_BULLET_MAX).map((line) => {
+      const stripped = line.replace(DESC_LINE_LEADING_LIST, '').trim();
+      const oneLine = normalizeDescriptionWhitespace(stripped);
+      if (oneLine.length <= DESC_BULLET_MAX_CHARS) {
+        return oneLine;
+      }
+      return `${oneLine.slice(0, DESC_BULLET_MAX_CHARS - 1)}…`;
+    });
+    return { kind: 'bullets', items };
+  }
+
+  const plain = normalizeDescriptionWhitespace(trimmed);
+  if (!plain) {
+    return { kind: 'none' };
+  }
+  return { kind: 'plain', text: plain };
+}
+
 export type ListingCardBadge = 'sold' | 'unavailable';
 
 export type ListingCardDensity = 'default' | 'home';
@@ -128,6 +180,23 @@ export default function ListingCard({
   const isWeb = Platform.OS === 'web';
   const conditionLabel = formatConditionLabel(listing.condition);
   const titleLines = isHomeDensity ? 2 : 3;
+  const descriptionPreview = useMemo(
+    () => buildDescriptionPreview(listing.description),
+    [listing.description]
+  );
+
+  const accessibilityDescriptionHint = useMemo(() => {
+    const raw =
+      descriptionPreview.kind === 'plain'
+        ? descriptionPreview.text
+        : descriptionPreview.kind === 'bullets'
+          ? descriptionPreview.items.join('. ')
+          : '';
+    if (raw.length <= 160) {
+      return raw;
+    }
+    return `${raw.slice(0, 157)}…`;
+  }, [descriptionPreview]);
 
   return (
     <Animated.View
@@ -150,7 +219,7 @@ export default function ListingCard({
           }
           onHoverIn={() => setIsHovered(true)}
           onHoverOut={() => setIsHovered(false)}
-          accessibilityLabel={`${listing.title}, $${formatPrice(listing.price)}${conditionLabel ? `, ${conditionLabel}` : ''}${badgeToShow ? `, ${badgeToShow === 'sold' ? 'Sold' : 'Unavailable'}` : ''}`}
+          accessibilityLabel={`${listing.title}, $${formatPrice(listing.price)}${conditionLabel ? `, ${conditionLabel}` : ''}${accessibilityDescriptionHint ? `, ${accessibilityDescriptionHint}` : ''}${badgeToShow ? `, ${badgeToShow === 'sold' ? 'Sold' : 'Unavailable'}` : ''}`}
           accessibilityRole="button"
         >
           <View
@@ -194,6 +263,29 @@ export default function ListingCard({
                 numberOfLines={1}
               >
                 {conditionLabel}
+              </Text>
+            ) : null}
+            {descriptionPreview.kind === 'bullets' ? (
+              <View style={[styles.descBlock, isHomeDensity && styles.descBlockHome]}>
+                {descriptionPreview.items.map((line, i) => (
+                  <Text
+                    key={`${listing._id}-desc-${i}`}
+                    style={[styles.descBulletLine, isHomeDensity && styles.descBulletLineHome]}
+                    numberOfLines={1}
+                    ellipsizeMode="tail"
+                  >
+                    {'\u2022 '}
+                    {line}
+                  </Text>
+                ))}
+              </View>
+            ) : descriptionPreview.kind === 'plain' ? (
+              <Text
+                style={[styles.descPlain, isHomeDensity && styles.descPlainHome]}
+                numberOfLines={2}
+                ellipsizeMode="tail"
+              >
+                {descriptionPreview.text}
               </Text>
             ) : null}
             <Text
@@ -351,6 +443,36 @@ const styles = StyleSheet.create({
   },
   listingConditionHome: {
     fontSize: 12,
+    marginTop: 0,
+  },
+  descBlock: {
+    marginTop: 2,
+    gap: 2,
+  },
+  descBlockHome: {
+    marginTop: 0,
+    gap: 1,
+  },
+  descBulletLine: {
+    ...typography.footnote,
+    fontSize: 12,
+    lineHeight: 16,
+    color: colors.text,
+  },
+  descBulletLineHome: {
+    fontSize: 11,
+    lineHeight: 15,
+  },
+  descPlain: {
+    ...typography.footnote,
+    fontSize: 12,
+    lineHeight: 16,
+    color: colors.text,
+    marginTop: 2,
+  },
+  descPlainHome: {
+    fontSize: 11,
+    lineHeight: 15,
     marginTop: 0,
   },
   listingPrice: {

--- a/frontend/components/ListingCard.tsx
+++ b/frontend/components/ListingCard.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'expo-router';
 import { Animated, Image, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import { motion } from '../theme/motion';
 import { formatPrice } from '../lib/formatPrice';
+import { buildDescriptionPreview } from '../lib/listingDescriptionPreview';
 import { colors, typography, borderRadius, spacing } from '../theme/tokens';
 import { useResolvedImageUrls } from '../hooks/useResolvedImageUrls';
 import { useReducedMotion } from '../hooks/useReducedMotion';
@@ -32,58 +33,6 @@ function formatConditionLabel(condition?: 'new' | 'used' | 'refurbished'): strin
     default:
       return null;
   }
-}
-
-const DESC_BULLET_MAX = 2;
-/** Per bullet — keeps cards scannable; ellipsis added in UI via numberOfLines. */
-const DESC_BULLET_MAX_CHARS = 78;
-const DESC_LINE_LEADING_LIST = /^\s*[-•*]\s+/;
-
-function normalizeDescriptionWhitespace(value: string): string {
-  return value.replace(/\s+/g, ' ').trim();
-}
-
-type DescriptionPreview =
-  | { kind: 'none' }
-  | { kind: 'plain'; text: string }
-  | { kind: 'bullets'; items: string[] };
-
-/** Short preview for the card: bullets when the seller used line breaks / list markers; else 2-line snippet. */
-function buildDescriptionPreview(raw: string): DescriptionPreview {
-  const trimmed = raw?.trim() ?? '';
-  if (!trimmed) {
-    return { kind: 'none' };
-  }
-
-  const lines = trimmed
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-
-  const looksLikeList =
-    lines.length >= 2 &&
-    lines.length <= 8 &&
-    lines.every((line) => line.length <= 220) &&
-    (lines.some((line) => DESC_LINE_LEADING_LIST.test(line)) ||
-      lines.every((line) => line.length <= 140));
-
-  if (looksLikeList) {
-    const items = lines.slice(0, DESC_BULLET_MAX).map((line) => {
-      const stripped = line.replace(DESC_LINE_LEADING_LIST, '').trim();
-      const oneLine = normalizeDescriptionWhitespace(stripped);
-      if (oneLine.length <= DESC_BULLET_MAX_CHARS) {
-        return oneLine;
-      }
-      return `${oneLine.slice(0, DESC_BULLET_MAX_CHARS - 1)}…`;
-    });
-    return { kind: 'bullets', items };
-  }
-
-  const plain = normalizeDescriptionWhitespace(trimmed);
-  if (!plain) {
-    return { kind: 'none' };
-  }
-  return { kind: 'plain', text: plain };
 }
 
 export type ListingCardBadge = 'sold' | 'unavailable';

--- a/frontend/lib/__tests__/listingDescriptionPreview.test.ts
+++ b/frontend/lib/__tests__/listingDescriptionPreview.test.ts
@@ -15,6 +15,18 @@ describe('buildDescriptionPreview', () => {
     }
   });
 
+  it('treats each Enter-separated line as a bullet even without markers or short-line limits', () => {
+    const lineA = 'A'.repeat(160);
+    const lineB = 'B'.repeat(160);
+    const r = buildDescriptionPreview(`${lineA}\n${lineB}`);
+    expect(r.kind).toBe('bullets');
+    if (r.kind === 'bullets') {
+      expect(r.items).toHaveLength(2);
+      expect(r.items[0]).toMatch(/^A+/);
+      expect(r.items[1]).toMatch(/^B+/);
+    }
+  });
+
   it('strips leading list markers', () => {
     const r = buildDescriptionPreview('- First point\n• Second\n1) Third');
     expect(r.kind).toBe('bullets');

--- a/frontend/lib/__tests__/listingDescriptionPreview.test.ts
+++ b/frontend/lib/__tests__/listingDescriptionPreview.test.ts
@@ -25,6 +25,34 @@ describe('buildDescriptionPreview', () => {
     }
   });
 
+  it('splits numbered lists without space after the dot and without sentence periods', () => {
+    const r = buildDescriptionPreview('1.Pickup near library\n2.Cash or Venmo only');
+    expect(r.kind).toBe('bullets');
+    if (r.kind === 'bullets') {
+      expect(r.items[0]).toContain('Pickup');
+      expect(r.items[1]).toContain('Venmo');
+    }
+  });
+
+  it('splits inline numbered items on one line', () => {
+    const r = buildDescriptionPreview('1. Pickup Tuesday 2. Cash only 3. Price firm');
+    expect(r.kind).toBe('bullets');
+    if (r.kind === 'bullets') {
+      expect(r.items).toHaveLength(3);
+      expect(r.items[0]).toMatch(/Pickup/);
+      expect(r.items[1]).toMatch(/Cash/);
+      expect(r.items[2]).toMatch(/firm/);
+    }
+  });
+
+  it('does not treat version numbers like 2.0 as list markers', () => {
+    const r = buildDescriptionPreview('Runs v2.0 firmware; like new; box included');
+    expect(r.kind).toBe('bullets');
+    if (r.kind === 'bullets') {
+      expect(r.items.join(' ')).not.toMatch(/^2\.0$/);
+    }
+  });
+
   it('drops unmarked prose after the last bullet line', () => {
     const r = buildDescriptionPreview(
       '- Pickup near campus\n- Cash or Venmo\nI can also deliver for an extra fee if you need that.'

--- a/frontend/lib/__tests__/listingDescriptionPreview.test.ts
+++ b/frontend/lib/__tests__/listingDescriptionPreview.test.ts
@@ -77,6 +77,28 @@ describe('buildDescriptionPreview', () => {
     }
   });
 
+  it('drops flush prose after the last numbered item', () => {
+    const r = buildDescriptionPreview(
+      '1. Pickup Tuesday\n2. Cash or Venmo\nContact me for other arrangements.'
+    );
+    expect(r.kind).toBe('bullets');
+    if (r.kind === 'bullets') {
+      expect(r.items).toHaveLength(2);
+      expect(r.items[1]).toContain('Venmo');
+      expect(r.items.join(' ')).not.toContain('Contact');
+    }
+  });
+
+  it('drops prose after a single dash bullet when the rest is unmarked', () => {
+    const r = buildDescriptionPreview('- Like new desk\nMust pick up this week from Poly.');
+    expect(r.kind).toBe('bullets');
+    if (r.kind === 'bullets') {
+      expect(r.items).toHaveLength(1);
+      expect(r.items[0]).toContain('desk');
+      expect(r.items.join(' ')).not.toContain('pick up this week');
+    }
+  });
+
   it('uses semicolon-separated clauses', () => {
     const r = buildDescriptionPreview(
       'Like new MacBook; includes charger and box; pickup Poly Canyon weekdays'

--- a/frontend/lib/__tests__/listingDescriptionPreview.test.ts
+++ b/frontend/lib/__tests__/listingDescriptionPreview.test.ts
@@ -25,6 +25,18 @@ describe('buildDescriptionPreview', () => {
     }
   });
 
+  it('drops unmarked prose after the last bullet line', () => {
+    const r = buildDescriptionPreview(
+      '- Pickup near campus\n- Cash or Venmo\nI can also deliver for an extra fee if you need that.'
+    );
+    expect(r.kind).toBe('bullets');
+    if (r.kind === 'bullets') {
+      expect(r.items).toHaveLength(2);
+      expect(r.items[1]).toContain('Venmo');
+      expect(r.items.join(' ')).not.toContain('deliver');
+    }
+  });
+
   it('uses semicolon-separated clauses', () => {
     const r = buildDescriptionPreview(
       'Like new MacBook; includes charger and box; pickup Poly Canyon weekdays'

--- a/frontend/lib/__tests__/listingDescriptionPreview.test.ts
+++ b/frontend/lib/__tests__/listingDescriptionPreview.test.ts
@@ -1,4 +1,4 @@
-import { buildDescriptionPreview } from '../listingDescriptionPreview';
+import { buildDescriptionPreview, DESC_PREVIEW_BULLET_MAX } from '../listingDescriptionPreview';
 
 describe('buildDescriptionPreview', () => {
   it('returns none for empty', () => {
@@ -34,6 +34,24 @@ describe('buildDescriptionPreview', () => {
       expect(r.items[0]).toBe('First point');
       expect(r.items[1]).toBe('Second');
       expect(r.items[2]).toBe('Third');
+    }
+  });
+
+  it('truncates long bullet lines at 78 characters with ellipsis', () => {
+    const longLine = 'A'.repeat(100);
+    const r = buildDescriptionPreview(`- ${longLine}\n- Short`);
+    expect(r.kind).toBe('bullets');
+    if (r.kind === 'bullets') {
+      expect(r.items[0].length).toBe(78);
+      expect(r.items[0].endsWith('…')).toBe(true);
+    }
+  });
+
+  it(`limits bullets to DESC_PREVIEW_BULLET_MAX (${DESC_PREVIEW_BULLET_MAX})`, () => {
+    const r = buildDescriptionPreview('- One\n- Two\n- Three\n- Four\n- Five');
+    expect(r.kind).toBe('bullets');
+    if (r.kind === 'bullets') {
+      expect(r.items).toHaveLength(DESC_PREVIEW_BULLET_MAX);
     }
   });
 

--- a/frontend/lib/__tests__/listingDescriptionPreview.test.ts
+++ b/frontend/lib/__tests__/listingDescriptionPreview.test.ts
@@ -1,0 +1,54 @@
+import { buildDescriptionPreview } from '../listingDescriptionPreview';
+
+describe('buildDescriptionPreview', () => {
+  it('returns none for empty', () => {
+    expect(buildDescriptionPreview('')).toEqual({ kind: 'none' });
+    expect(buildDescriptionPreview('   \n')).toEqual({ kind: 'none' });
+  });
+
+  it('uses line breaks / markers as bullets', () => {
+    const r = buildDescriptionPreview('Great desk\nPickup near campus\nCash only');
+    expect(r.kind).toBe('bullets');
+    if (r.kind === 'bullets') {
+      expect(r.items).toHaveLength(3);
+      expect(r.items[0]).toContain('Great desk');
+    }
+  });
+
+  it('strips leading list markers', () => {
+    const r = buildDescriptionPreview('- First point\n• Second\n1) Third');
+    expect(r.kind).toBe('bullets');
+    if (r.kind === 'bullets') {
+      expect(r.items[0]).toBe('First point');
+      expect(r.items[1]).toBe('Second');
+      expect(r.items[2]).toBe('Third');
+    }
+  });
+
+  it('uses semicolon-separated clauses', () => {
+    const r = buildDescriptionPreview(
+      'Like new MacBook; includes charger and box; pickup Poly Canyon weekdays'
+    );
+    expect(r.kind).toBe('bullets');
+    if (r.kind === 'bullets') {
+      expect(r.items.length).toBeGreaterThanOrEqual(2);
+      expect(r.items[0]).toMatch(/MacBook/i);
+    }
+  });
+
+  it('falls back to sentence bullets for prose with multiple sentences', () => {
+    const r = buildDescriptionPreview(
+      'Selling my bike because I am graduating. Tires replaced last year. Great for campus hills.'
+    );
+    if (r.kind === 'bullets') {
+      expect(r.items.length).toBeGreaterThanOrEqual(2);
+    } else {
+      expect(r.kind).toBe('plain');
+    }
+  });
+
+  it('uses plain for a single short sentence', () => {
+    const r = buildDescriptionPreview('One owner, smoke free.');
+    expect(r.kind).toBe('plain');
+  });
+});

--- a/frontend/lib/listingDescriptionPreview.ts
+++ b/frontend/lib/listingDescriptionPreview.ts
@@ -35,6 +35,16 @@ function tryLineBasedBullets(trimmed: string): string[] | null {
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
 
+  const markedLines = lines.filter((line) => DESC_LINE_LEADING_MARKERS.test(line));
+
+  // Two or more real list lines: only those — omit trailing prose after the last bullet.
+  if (markedLines.length >= 2) {
+    return markedLines.slice(0, DESC_PREVIEW_BULLET_MAX).map((line) => {
+      const stripped = stripLeadingMarker(line);
+      return capOneLine(normalizeDescriptionWhitespace(stripped));
+    });
+  }
+
   const looksLikeList =
     lines.length >= 2 &&
     lines.length <= 10 &&

--- a/frontend/lib/listingDescriptionPreview.ts
+++ b/frontend/lib/listingDescriptionPreview.ts
@@ -34,6 +34,35 @@ function stripLeadingMarker(line: string): string {
 }
 
 /**
+ * Within one numbered item's raw slice, drop flush-left lines after the first (prose after the list).
+ * Keeps indented lines as soft-wrapped continuation of the same bullet.
+ */
+function trimListItemBodyChunk(chunk: string): string {
+  const raw = chunk.replace(/\r\n/g, '\n').trimEnd();
+  if (!raw.includes('\n')) {
+    return raw.trim();
+  }
+  const rawLines = raw.split('\n');
+  const kept: string[] = [];
+  for (let i = 0; i < rawLines.length; i++) {
+    const line = rawLines[i] ?? '';
+    if (i === 0) {
+      kept.push(line.trimEnd());
+      continue;
+    }
+    if (line.trim() === '') {
+      break;
+    }
+    if (/^(?:\s{2,}\S|\t+\S)/.test(line)) {
+      kept.push(line.trimEnd());
+    } else {
+      break;
+    }
+  }
+  return kept.join('\n').trim();
+}
+
+/**
  * Finds "1. … 2. …" (and "1.Item" without space after the dot) anywhere in the text.
  * Does not treat "2.0" as a list marker.
  */
@@ -52,13 +81,7 @@ function tryNumberedSpans(trimmed: string): string[] | null {
   for (let i = 0; i < indices.length; i++) {
     const from = indices[i].contentStart;
     const to = i + 1 < indices.length ? indices[i + 1].markStart : t.length;
-    let chunk = t.slice(from, to);
-    if (i === indices.length - 1) {
-      const firstPara = chunk.split(/\n\s*\n/)[0];
-      if (firstPara !== undefined) {
-        chunk = firstPara;
-      }
-    }
+    const chunk = trimListItemBodyChunk(t.slice(from, to));
     const normalized = normalizeDescriptionWhitespace(chunk.trim());
     if (normalized.length > 0) {
       items.push(normalized);
@@ -89,6 +112,15 @@ function tryLineBasedBullets(trimmed: string): string[] | null {
       const stripped = stripLeadingMarker(line);
       return capOneLine(normalizeDescriptionWhitespace(stripped));
     });
+  }
+
+  // One marked line then flush-left lines (no indented wrap): list + prose — only the list line(s).
+  if (markedLines.length === 1 && lines.length >= 2) {
+    const afterMarked = lines.filter((line) => !LINE_START_MARKER.test(line));
+    const allAfterAreProse = afterMarked.every((line) => !/^(?:\s{2,}\S|\t+\S)/.test(line));
+    if (allAfterAreProse) {
+      return [capOneLine(normalizeDescriptionWhitespace(stripLeadingMarker(markedLines[0] ?? '')))];
+    }
   }
 
   // Any other multi-line description: each line is a bullet (seller pressed Enter between lines).

--- a/frontend/lib/listingDescriptionPreview.ts
+++ b/frontend/lib/listingDescriptionPreview.ts
@@ -6,7 +6,12 @@
 
 export const DESC_PREVIEW_BULLET_MAX = 3;
 const DESC_BULLET_MAX_CHARS = 78;
-const DESC_LINE_LEADING_MARKERS = /^\s*(?:[-•*]|\d{1,2}(?:\.|\)|\]))\s+/;
+
+/** Line starts a list item: dash/bullet, or 1. / 1) (space after dot optional; avoids 2.0 decimals). */
+const LINE_START_MARKER = /^\s*(?:[-•*]\s+|\d{1,2}\)\s+|\d{1,2}\.(?!\d)(?:\s+|$|(?=\S)))/;
+
+/** Same markers appear after newline or space — for inline "1. a 2. b" without line breaks. */
+const NUMBERED_ITEM_MARKER = /(?:^|[\n\s])(\d{1,2})\.(?!\d)(?:\s+|$|(?=\S)|(?=\n))/g;
 
 export type DescriptionPreview =
   | { kind: 'none' }
@@ -25,7 +30,41 @@ function capOneLine(oneLine: string): string {
 }
 
 function stripLeadingMarker(line: string): string {
-  return line.replace(DESC_LINE_LEADING_MARKERS, '').trim();
+  return line.replace(LINE_START_MARKER, '').trim();
+}
+
+/**
+ * Finds "1. … 2. …" (and "1.Item" without space after the dot) anywhere in the text.
+ * Does not treat "2.0" as a list marker.
+ */
+function tryNumberedSpans(trimmed: string): string[] | null {
+  const t = trimmed.replace(/\r\n/g, '\n');
+  const indices: { markStart: number; contentStart: number }[] = [];
+  for (const m of t.matchAll(NUMBERED_ITEM_MARKER)) {
+    if (m.index !== undefined) {
+      indices.push({ markStart: m.index, contentStart: m.index + m[0].length });
+    }
+  }
+  if (indices.length < 2) {
+    return null;
+  }
+  const items: string[] = [];
+  for (let i = 0; i < indices.length; i++) {
+    const from = indices[i].contentStart;
+    const to = i + 1 < indices.length ? indices[i + 1].markStart : t.length;
+    let chunk = t.slice(from, to);
+    if (i === indices.length - 1) {
+      const firstPara = chunk.split(/\n\s*\n/)[0];
+      if (firstPara !== undefined) {
+        chunk = firstPara;
+      }
+    }
+    const normalized = normalizeDescriptionWhitespace(chunk.trim());
+    if (normalized.length > 0) {
+      items.push(normalized);
+    }
+  }
+  return items.length >= 2 ? items : null;
 }
 
 /** Newlines / explicit list markers → bullets. */
@@ -35,7 +74,7 @@ function tryLineBasedBullets(trimmed: string): string[] | null {
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
 
-  const markedLines = lines.filter((line) => DESC_LINE_LEADING_MARKERS.test(line));
+  const markedLines = lines.filter((line) => LINE_START_MARKER.test(line));
 
   // Two or more real list lines: only those — omit trailing prose after the last bullet.
   if (markedLines.length >= 2) {
@@ -49,7 +88,7 @@ function tryLineBasedBullets(trimmed: string): string[] | null {
     lines.length >= 2 &&
     lines.length <= 10 &&
     lines.every((line) => line.length <= 220) &&
-    (lines.some((line) => DESC_LINE_LEADING_MARKERS.test(line)) ||
+    (lines.some((line) => LINE_START_MARKER.test(line)) ||
       lines.every((line) => line.length <= 140));
 
   if (!looksLikeList) {
@@ -125,6 +164,14 @@ export function buildDescriptionPreview(raw: string): DescriptionPreview {
   const trimmed = raw?.trim() ?? '';
   if (!trimmed) {
     return { kind: 'none' };
+  }
+
+  const fromNumbered = tryNumberedSpans(trimmed);
+  if (fromNumbered) {
+    return {
+      kind: 'bullets',
+      items: fromNumbered.slice(0, DESC_PREVIEW_BULLET_MAX).map(capOneLine),
+    };
   }
 
   const fromLines = tryLineBasedBullets(trimmed);

--- a/frontend/lib/listingDescriptionPreview.ts
+++ b/frontend/lib/listingDescriptionPreview.ts
@@ -67,12 +67,19 @@ function tryNumberedSpans(trimmed: string): string[] | null {
   return items.length >= 2 ? items : null;
 }
 
-/** Newlines / explicit list markers → bullets. */
+/**
+ * Line breaks from the user (Enter) → one bullet per non-empty line.
+ * If two or more lines start with a list marker, only those lines are used so prose after the list is omitted.
+ */
 function tryLineBasedBullets(trimmed: string): string[] | null {
   const lines = trimmed
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
+
+  if (lines.length < 2) {
+    return null;
+  }
 
   const markedLines = lines.filter((line) => LINE_START_MARKER.test(line));
 
@@ -84,14 +91,11 @@ function tryLineBasedBullets(trimmed: string): string[] | null {
     });
   }
 
-  const looksLikeList =
-    lines.length >= 2 &&
-    lines.length <= 10 &&
-    lines.every((line) => line.length <= 220) &&
-    (lines.some((line) => LINE_START_MARKER.test(line)) ||
-      lines.every((line) => line.length <= 140));
-
-  if (!looksLikeList) {
+  // Any other multi-line description: each line is a bullet (seller pressed Enter between lines).
+  if (lines.length > 12) {
+    return null;
+  }
+  if (!lines.every((line) => line.length <= 300)) {
     return null;
   }
 

--- a/frontend/lib/listingDescriptionPreview.ts
+++ b/frontend/lib/listingDescriptionPreview.ts
@@ -1,0 +1,141 @@
+/**
+ * Turns listing descriptions into a short card preview: bullet key points when
+ * structure is detectable (lists, semicolons, sentences); otherwise a plain snippet.
+ * No ML — lightweight heuristics only.
+ */
+
+export const DESC_PREVIEW_BULLET_MAX = 3;
+const DESC_BULLET_MAX_CHARS = 78;
+const DESC_LINE_LEADING_MARKERS = /^\s*(?:[-•*]|\d{1,2}(?:\.|\)|\]))\s+/;
+
+export type DescriptionPreview =
+  | { kind: 'none' }
+  | { kind: 'plain'; text: string }
+  | { kind: 'bullets'; items: string[] };
+
+export function normalizeDescriptionWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function capOneLine(oneLine: string): string {
+  if (oneLine.length <= DESC_BULLET_MAX_CHARS) {
+    return oneLine;
+  }
+  return `${oneLine.slice(0, DESC_BULLET_MAX_CHARS - 1)}…`;
+}
+
+function stripLeadingMarker(line: string): string {
+  return line.replace(DESC_LINE_LEADING_MARKERS, '').trim();
+}
+
+/** Newlines / explicit list markers → bullets. */
+function tryLineBasedBullets(trimmed: string): string[] | null {
+  const lines = trimmed
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  const looksLikeList =
+    lines.length >= 2 &&
+    lines.length <= 10 &&
+    lines.every((line) => line.length <= 220) &&
+    (lines.some((line) => DESC_LINE_LEADING_MARKERS.test(line)) ||
+      lines.every((line) => line.length <= 140));
+
+  if (!looksLikeList) {
+    return null;
+  }
+
+  return lines.slice(0, DESC_PREVIEW_BULLET_MAX).map((line) => {
+    const stripped = stripLeadingMarker(line);
+    return capOneLine(normalizeDescriptionWhitespace(stripped));
+  });
+}
+
+/** "Pickup on campus; cash only; includes charger" → bullets. */
+function trySemicolonBullets(text: string): string[] | null {
+  if (!text.includes(';')) {
+    return null;
+  }
+  const parts = text
+    .split(';')
+    .map((p) => normalizeDescriptionWhitespace(p))
+    .filter((p) => p.length >= 10);
+  if (parts.length < 2 || parts.length > 8) {
+    return null;
+  }
+  if (!parts.every((p) => p.length <= 200)) {
+    return null;
+  }
+  return parts.slice(0, DESC_PREVIEW_BULLET_MAX).map(capOneLine);
+}
+
+function segmentSentencesIntl(text: string): string[] | null {
+  try {
+    const Ctor = Intl.Segmenter;
+    if (typeof Ctor !== 'function') {
+      return null;
+    }
+    const segmenter = new Ctor('en', { granularity: 'sentence' });
+    const out: string[] = [];
+    for (const { segment } of segmenter.segment(text)) {
+      const s = normalizeDescriptionWhitespace(segment);
+      if (s.length >= 18 && s.length <= 280) {
+        out.push(s);
+      }
+    }
+    return out.length > 0 ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Rough sentence split when Intl.Segmenter is unavailable (e.g. some Hermes builds). */
+function segmentSentencesFallback(text: string): string[] {
+  const normalized = normalizeDescriptionWhitespace(text);
+  if (!normalized) {
+    return [];
+  }
+  const chunks = normalized.split(/(?<=[.!?])\s+(?=[A-Z0-9"'(])/).map((s) => s.trim());
+  return chunks.filter((s) => s.length >= 18 && s.length <= 280);
+}
+
+function trySentenceBullets(text: string): string[] | null {
+  const sentences = segmentSentencesIntl(text) ?? segmentSentencesFallback(text);
+  if (sentences.length < 2) {
+    return null;
+  }
+  return sentences.slice(0, DESC_PREVIEW_BULLET_MAX).map(capOneLine);
+}
+
+/**
+ * Prefer structured bullets; otherwise one normalized paragraph for a 2-line ellipsis in the UI.
+ */
+export function buildDescriptionPreview(raw: string): DescriptionPreview {
+  const trimmed = raw?.trim() ?? '';
+  if (!trimmed) {
+    return { kind: 'none' };
+  }
+
+  const fromLines = tryLineBasedBullets(trimmed);
+  if (fromLines) {
+    return { kind: 'bullets', items: fromLines };
+  }
+
+  const normalizedOneLine = normalizeDescriptionWhitespace(trimmed);
+
+  const fromSemi = trySemicolonBullets(trimmed);
+  if (fromSemi) {
+    return { kind: 'bullets', items: fromSemi };
+  }
+
+  const fromSentences = trySentenceBullets(trimmed);
+  if (fromSentences) {
+    return { kind: 'bullets', items: fromSentences };
+  }
+
+  if (!normalizedOneLine) {
+    return { kind: 'none' };
+  }
+  return { kind: 'plain', text: normalizedOneLine };
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@sentry/react-native": "^8.3.0",
     "@convex-dev/auth": "^0.0.90",
     "@expo/metro-runtime": "~55.0.6",
     "@expo/vector-icons": "^15.0.3",

--- a/frontend/theme/tokens.ts
+++ b/frontend/theme/tokens.ts
@@ -59,6 +59,8 @@ export const colors = {
 export const spacing = {
   xs: 4,
   sm: 8,
+  /** Between sm and md — compact card gutters */
+  smPlus: 10,
   md: 12,
   lg: 16,
   xl: 20,

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -16,5 +16,5 @@
     }
   },
   "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/__tests__/**"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "packages/shared"
       ],
       "dependencies": {
-        "@sentry/react-native": "^8.3.0",
         "convex": "^1.32.0"
       },
       "devDependencies": {
@@ -70,6 +69,7 @@
         "@expo/vector-icons": "^15.0.3",
         "@polybuys/shared": "*",
         "@react-native-async-storage/async-storage": "2.2.0",
+        "@sentry/react-native": "^8.3.0",
         "convex": "^1.32.0",
         "expo": "~55.0.5",
         "expo-constants": "~55.0.7",
@@ -5000,7 +5000,7 @@
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6541,7 +6541,7 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -15560,7 +15560,7 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     ]
   },
   "dependencies": {
-    "@sentry/react-native": "^8.3.0",
     "convex": "^1.32.0"
   }
 }


### PR DESCRIPTION
## Linked Issues

Closes #81
Linear: POLY-76 (e.g., POLY-123)

## Summary

Briefly explain the change and why.

## How to Test

Steps to verify locally:

- `npm run lint`
- `npm run typecheck`
- `npm test`
- Manual flow:
  1. `npm run dev:backend` (in terminal A)
  2. `npm run dev` (in terminal B)
  3. Verify the change: <describe expected behavior/screens>

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Lint/tests pass locally (`npm run lint`)
- [ ] Docs updated (README/ADR/changelog if needed)
- [ ] Follows conventional commit format
- [ ] No merge conflicts with `dev`

## Screenshots / Demos

(if UI or visible behavior - attach images, videos, or GIFs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Listing cards now display item condition (new/used/refurbished).
  * Description previews appear on listing cards with improved formatting.

* **Improvements**
  * Enhanced listing card styling with updated spacing and typography.
  * Improved accessibility with more descriptive labels for listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->