### PR TITLE
feat: add Other as a report reason for listing moderation (POLY-70)

### DIFF
--- a/backend/convex/__tests__/reports.test.ts
+++ b/backend/convex/__tests__/reports.test.ts
@@ -733,4 +733,73 @@ describe('Reports mutations', () => {
     expect(listing?.hiddenReason).toBe('manual_admin_action'); // Should NOT be 'auto_moderation'
     expect(listing?.hiddenAt).toBe(originalHiddenAt); // Should prevent update
   });
+
+  it('createReport succeeds with "other" reason and notes', async () => {
+    const t = convexTest(schema as any, modules);
+
+    const listingId = await createTestListing(t, 'seller-id');
+
+    const asUser = t.withIdentity({
+      name: 'Reporter',
+      subject: 'reporter-subject',
+      email: 'reporter@calpoly.edu',
+    });
+
+    const reportId = await asUser.mutation(api.reports.createReport, {
+      targetId: listingId,
+      targetType: 'listing',
+      reason: 'other',
+      notes: 'This listing has misleading photos',
+    });
+
+    const report = await t.run(async (ctx: any) => {
+      return await ctx.db.get(reportId);
+    });
+
+    expect(report).toMatchObject({
+      reason: 'other',
+      notes: 'This listing has misleading photos',
+    });
+  });
+
+  it('createReport with "other" reason fails without notes', async () => {
+    const t = convexTest(schema as any, modules);
+
+    const listingId = await createTestListing(t, 'seller-id');
+
+    const asUser = t.withIdentity({
+      name: 'Reporter',
+      subject: 'reporter-subject',
+      email: 'reporter@calpoly.edu',
+    });
+
+    await expect(async () => {
+      await asUser.mutation(api.reports.createReport, {
+        targetId: listingId,
+        targetType: 'listing',
+        reason: 'other',
+      });
+    }).rejects.toThrow('Please provide details when selecting "Other" as the reason');
+  });
+
+  it('createReport with "other" reason fails with empty notes', async () => {
+    const t = convexTest(schema as any, modules);
+
+    const listingId = await createTestListing(t, 'seller-id');
+
+    const asUser = t.withIdentity({
+      name: 'Reporter',
+      subject: 'reporter-subject',
+      email: 'reporter@calpoly.edu',
+    });
+
+    await expect(async () => {
+      await asUser.mutation(api.reports.createReport, {
+        targetId: listingId,
+        targetType: 'listing',
+        reason: 'other',
+        notes: '   ',
+      });
+    }).rejects.toThrow('Please provide details when selecting "Other" as the reason');
+  });
 });

--- a/backend/convex/reports.ts
+++ b/backend/convex/reports.ts
@@ -16,7 +16,12 @@ export const createReport = mutation({
   args: {
     targetId: v.string(),
     targetType: v.union(v.literal('listing'), v.literal('profile')),
-    reason: v.union(v.literal('scam'), v.literal('inappropriate'), v.literal('spam')),
+    reason: v.union(
+      v.literal('scam'),
+      v.literal('inappropriate'),
+      v.literal('spam'),
+      v.literal('other')
+    ),
     notes: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
@@ -25,6 +30,11 @@ export const createReport = mutation({
     // 2. Validate notes length if provided
     if (args.notes && args.notes.length > MAX_NOTES_LENGTH) {
       throw new ConvexError(`Notes must be ${MAX_NOTES_LENGTH} characters or less`);
+    }
+
+    // Require notes when reason is "other" so moderators have context
+    if (args.reason === 'other' && (!args.notes || args.notes.trim().length === 0)) {
+      throw new ConvexError('Please provide details when selecting "Other" as the reason');
     }
 
     // 5. Validate target exists and handle malformed IDs

--- a/backend/convex/schema.ts
+++ b/backend/convex/schema.ts
@@ -108,7 +108,12 @@ export default defineSchema({
     targetId: v.string(), // Can be listing or profile ID
     targetType: v.union(v.literal('listing'), v.literal('profile')),
     reporterId: v.string(), // Auth identity subject
-    reason: v.union(v.literal('scam'), v.literal('inappropriate'), v.literal('spam')),
+    reason: v.union(
+      v.literal('scam'),
+      v.literal('inappropriate'),
+      v.literal('spam'),
+      v.literal('other')
+    ),
     notes: v.optional(v.string()),
     createdAt: v.number(),
   })

--- a/frontend/components/ReportModal.tsx
+++ b/frontend/components/ReportModal.tsx
@@ -4,7 +4,7 @@ import { colors } from '../theme/tokens';
 import { useMutation } from 'convex/react';
 import { api } from 'convex/_generated/api';
 
-type ReportReason = 'scam' | 'inappropriate' | 'spam';
+type ReportReason = 'scam' | 'inappropriate' | 'spam' | 'other';
 
 type ReportModalProps = {
   isVisible: boolean;
@@ -17,6 +17,7 @@ const REASONS: { value: ReportReason; label: string; desc: string }[] = [
   { value: 'scam', label: 'Scam', desc: 'Fraudulent listing or deceptive behavior' },
   { value: 'inappropriate', label: 'Inappropriate', desc: 'Offensive or policy-violating content' },
   { value: 'spam', label: 'Spam', desc: 'Low-quality, duplicate, or irrelevant posting' },
+  { value: 'other', label: 'Other', desc: 'Something else not covered above' },
 ];
 
 const MAX_NOTES = 500;
@@ -40,6 +41,10 @@ export function ReportModal({ isVisible, onClose, targetId, targetType }: Report
 
   const handleSubmit = async () => {
     if (!reason || submitting) return;
+    if (reason === 'other' && !notes.trim()) {
+      Alert.alert('Notes required', 'Please provide details when selecting "Other" as the reason.');
+      return;
+    }
     setSubmitting(true);
     try {
       await createReport({
@@ -79,7 +84,9 @@ export function ReportModal({ isVisible, onClose, targetId, targetType }: Report
             </Pressable>
           ))}
 
-          <Text style={styles.subtitle}>Notes (optional)</Text>
+          <Text style={styles.subtitle}>
+            {reason === 'other' ? 'Notes (required)' : 'Notes (optional)'}
+          </Text>
           <TextInput
             style={styles.notesInput}
             multiline


### PR DESCRIPTION
**Linear: POLY-70**

### Summary
Adds an "Other" option to the report flow so users can report edge cases that don't fit scam, inappropriate, or spam. Notes are required when "Other" is selected so moderators have context.

### Changes

**Backend**
- Added `'other'` to the `reason` union in reports schema and `createReport` mutation args
- Added validation: submitting with reason `'other'` requires non-empty notes

**Frontend**
- Added `'other'` to `ReportReason` type and `REASONS` array in ReportModal
- Notes label dynamically shows "(required)" when "Other" is selected
- Client-side validation blocks submit without notes when reason is "Other"

**Tests**
- Added 3 new tests: success with "other" + notes, failure without notes, failure with whitespace-only notes

### Testing
- 154 tests pass, lint clean

Made with Kiro