### PR TITLE
Implement profile pictures

### DIFF
--- a/backend/convex/messages.ts
+++ b/backend/convex/messages.ts
@@ -515,6 +515,7 @@ export const listUserConversations = query({
           otherUser: {
             id: group.otherUserId,
             name: displayNameFromProfile(otherProfile, otherUserDoc),
+            picture: otherProfile?.picture,
           },
           listing: listingSummariesById.get(group.primaryConversation.listingId) ?? {
             id: group.primaryConversation.listingId,

--- a/backend/convex/profiles.ts
+++ b/backend/convex/profiles.ts
@@ -167,7 +167,7 @@ export const updateProfile = mutation({
     name: v.optional(v.string()),
     email: v.optional(v.string()),
     bio: v.optional(v.string()),
-    picture: v.optional(v.id('_storage')),
+    picture: v.optional(v.union(v.id('_storage'), v.null())),
     major: v.optional(v.string()),
     year: v.optional(v.number()),
     joinDate: v.optional(v.number()),
@@ -209,7 +209,27 @@ export const updateProfile = mutation({
       }
       update.bio = args.bio;
     }
-    if (args.picture !== undefined) update.picture = args.picture;
+    if (args.picture !== undefined) {
+      if (args.picture === null) {
+        if (profile.picture) {
+          try {
+            await ctx.storage.delete(profile.picture);
+          } catch {
+            // Non-fatal: keep profile update path resilient.
+          }
+        }
+        update.picture = undefined;
+      } else {
+        if (profile.picture && profile.picture !== args.picture) {
+          try {
+            await ctx.storage.delete(profile.picture);
+          } catch {
+            // Non-fatal: keep profile update path resilient.
+          }
+        }
+        update.picture = args.picture;
+      }
+    }
     if (args.major !== undefined) {
       if (
         args.major.length < PAYLOAD_BOUNDS.MAJOR_MIN ||

--- a/frontend/app/(tabs)/inbox.tsx
+++ b/frontend/app/(tabs)/inbox.tsx
@@ -3,7 +3,6 @@ import {
   ActivityIndicator,
   Animated,
   FlatList,
-  Image,
   Platform,
   Pressable,
   StyleSheet,
@@ -20,6 +19,8 @@ import { api } from 'convex/_generated/api';
 import { Id } from 'convex/_generated/dataModel';
 import { useEntranceAnimation } from '../../hooks/useEntranceAnimation';
 import { useAuth } from '../../hooks/useAuth';
+import { useResolvedImageUrls } from '../../hooks/useResolvedImageUrls';
+import ProfileAvatar from '../../components/ProfileAvatar';
 import { ScreenState } from '../../components/ScreenState';
 import OpenInAppPrompt from '../../components/OpenInAppPrompt';
 import { ScreenHeader } from '../../components/ui';
@@ -35,6 +36,7 @@ type ConversationRowItem = {
   lastMessageAt?: number;
   otherUser?: {
     name?: string;
+    picture?: string;
   };
   listing?: {
     id?: Id<'listings'>;
@@ -50,12 +52,14 @@ function ItemSeparator() {
 function ConversationRow({
   item,
   index,
+  avatarUrl,
   entranceStyle,
   onPress,
   formatTimestamp,
 }: {
   item: ConversationRowItem;
   index: number;
+  avatarUrl: string | null;
   entranceStyle: object;
   onPress: () => void;
   formatTimestamp: (timestamp: number) => string;
@@ -63,7 +67,6 @@ function ConversationRow({
   const hasUnread = Boolean(item.hasUnread);
   const otherUserName = item.otherUser?.name ?? 'User';
   const listingTitle = item.listing?.title ?? 'Listing unavailable';
-  const thumbnail = item.listing?.thumbnailUrl ?? null;
 
   const lastMessagePreview = item.lastMessagePreview ?? 'Conversation started';
   const lastMessageAt = item.lastMessageAt ?? item.updatedAt ?? Date.now();
@@ -76,13 +79,7 @@ function ConversationRow({
         accessibilityRole="button"
         accessibilityLabel={`Conversation with ${otherUserName} about ${listingTitle}`}
       >
-        {thumbnail ? (
-          <Image source={{ uri: thumbnail }} style={styles.thumbnail} />
-        ) : (
-          <View style={[styles.thumbnail, styles.thumbnailPlaceholder]}>
-            <Text style={styles.thumbnailPlaceholderText}>No image</Text>
-          </View>
-        )}
+        <ProfileAvatar uri={avatarUrl} name={otherUserName} size={56} style={styles.avatar} />
         <View style={styles.rowBody}>
           <View style={styles.rowTop}>
             <Text style={[styles.otherUserName, hasUnread && styles.unreadText]} numberOfLines={1}>
@@ -173,7 +170,17 @@ export default function InboxScreen() {
     conversations?.filter(
       (conversation) => Boolean(conversation.hasUnread) || (conversation.unreadCount ?? 0) > 0
     ).length ?? 0;
-
+  const otherUserPictureIds = useMemo(
+    () =>
+      (conversations ?? [])
+        .map((conversation) => conversation.otherUser?.picture)
+        .filter(
+          (pictureId): pictureId is Id<'_storage'> =>
+            typeof pictureId === 'string' && pictureId.length > 0
+        ),
+    [conversations]
+  );
+  const { resolvedUrls: resolvedOtherUserAvatarUrls } = useResolvedImageUrls(otherUserPictureIds);
   const filteredConversations = useMemo(() => {
     if (!conversations) return [];
     const query = searchText.trim().toLowerCase();
@@ -292,20 +299,29 @@ export default function InboxScreen() {
               />
             </View>
           }
-          renderItem={({ item, index }) => (
-            <ConversationRow
-              item={item as ConversationRowItem}
-              index={index}
-              entranceStyle={entranceStyle}
-              formatTimestamp={formatTimestamp}
-              onPress={() =>
-                router.push({
-                  pathname: '/conversations/[id]',
-                  params: { id: String(item._id) },
-                } as never)
-              }
-            />
-          )}
+          renderItem={({ item, index }) => {
+            const conversation = item as ConversationRowItem;
+            const pictureId =
+              typeof conversation.otherUser?.picture === 'string'
+                ? conversation.otherUser.picture
+                : null;
+            const avatarUrl = pictureId ? (resolvedOtherUserAvatarUrls[pictureId] ?? null) : null;
+            return (
+              <ConversationRow
+                item={conversation}
+                index={index}
+                avatarUrl={avatarUrl}
+                entranceStyle={entranceStyle}
+                formatTimestamp={formatTimestamp}
+                onPress={() =>
+                  router.push({
+                    pathname: '/conversations/[id]',
+                    params: { id: String(item._id) },
+                  } as never)
+                }
+              />
+            );
+          }}
           ItemSeparatorComponent={ItemSeparator}
         />
       </View>
@@ -403,21 +419,11 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: spacing.md,
   },
-  thumbnail: {
+  avatar: {
     width: 56,
     height: 56,
-    borderRadius: borderRadius.sm,
+    borderRadius: 28,
     backgroundColor: colors.border,
-  },
-  thumbnailPlaceholder: {
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  thumbnailPlaceholderText: {
-    ...typography.footnote,
-    color: colors.muted,
-    textTransform: 'uppercase',
-    fontWeight: '600',
   },
   rowBody: {
     flex: 1,

--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import {
   Animated,
-  Image,
   Platform,
   Pressable,
   ScrollView,
@@ -19,6 +18,7 @@ import { useEntranceAnimation } from '../../hooks/useEntranceAnimation';
 import { useResolvedImageUrls } from '../../hooks/useResolvedImageUrls';
 import ListingCard from '../../components/ListingCard';
 import OpenInAppPrompt from '../../components/OpenInAppPrompt';
+import ProfileAvatar from '../../components/ProfileAvatar';
 import { ScreenState } from '../../components/ScreenState';
 import { FilterChips, type FilterChipOption } from '../../components/ui';
 import { colors, typography, spacing, borderRadius } from '../../theme/tokens';
@@ -152,15 +152,7 @@ export default function SettingsScreen() {
       {topSafeSpace > 0 && <View style={{ height: topSafeSpace }} />}
       <Animated.View style={[styles.profileBlock, entranceStyle]}>
         <View style={styles.profileHeader}>
-          {avatarUrl ? (
-            <Image source={{ uri: avatarUrl }} style={styles.avatar} />
-          ) : (
-            <View style={[styles.avatar, styles.avatarPlaceholder]}>
-              <Text style={styles.avatarPlaceholderText}>
-                {profile.name.charAt(0).toUpperCase()}
-              </Text>
-            </View>
-          )}
+          <ProfileAvatar uri={avatarUrl} name={profile.name} size={72} style={styles.avatar} />
           <View style={styles.profileInfo}>
             <Text style={styles.profileName}>{profile.name}</Text>
             <Text style={styles.profileMeta}>{profileSubtitle}</Text>
@@ -343,14 +335,6 @@ const styles = StyleSheet.create({
     height: 72,
     borderRadius: 36,
     backgroundColor: colors.border,
-  },
-  avatarPlaceholder: {
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  avatarPlaceholderText: {
-    ...typography.title1,
-    color: colors.primary,
   },
   profileInfo: {
     flex: 1,

--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -112,7 +112,7 @@ export default function SettingsScreen() {
       <ScrollView
         style={styles.container}
         contentContainerStyle={styles.centeredState}
-        contentInsetAdjustmentBehavior="automatic"
+        contentInsetAdjustmentBehavior="never"
       >
         <Animated.View style={[styles.signInCard, entranceStyle]}>
           <Text style={styles.signInTitle}>Complete your profile</Text>
@@ -146,7 +146,7 @@ export default function SettingsScreen() {
   return (
     <ScrollView
       style={styles.container}
-      contentInsetAdjustmentBehavior="automatic"
+      contentInsetAdjustmentBehavior="never"
       contentContainerStyle={styles.content}
     >
       {topSafeSpace > 0 && <View style={{ height: topSafeSpace }} />}

--- a/frontend/app/conversations/[id].tsx
+++ b/frontend/app/conversations/[id].tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   FlatList,
-  Image,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -19,6 +18,7 @@ import { api } from 'convex/_generated/api';
 import { Id } from 'convex/_generated/dataModel';
 import { useAuth } from '../../hooks/useAuth';
 import { useResolvedImageUrls } from '../../hooks/useResolvedImageUrls';
+import ProfileAvatar from '../../components/ProfileAvatar';
 import SafetyBanner from '../../components/SafetyBanner';
 import { ScreenState } from '../../components/ScreenState';
 import { colors, typography, spacing, borderRadius } from '../../theme/tokens';
@@ -99,13 +99,11 @@ export default function ConversationDetailScreen() {
     conversation?.listingId ??
     null) as Id<'listings'> | null;
   const listing = useQuery(api.listings.getListing, listingId ? { id: listingId } : 'skip');
-  const headerThumbnailSource =
-    conversation?.listing?.thumbnailUrl ??
-    (listing?.images && listing.images.length > 0 ? listing.images[0] : null);
-  const { mappedUrls: headerMappedUrls } = useResolvedImageUrls(
-    headerThumbnailSource ? [headerThumbnailSource] : []
+  const headerOtherUserPicture = conversation?.otherUser?.picture ?? null;
+  const { mappedUrls: headerAvatarMappedUrls } = useResolvedImageUrls(
+    headerOtherUserPicture ? [headerOtherUserPicture] : []
   );
-  const headerThumbnailUrl = headerMappedUrls[0] ?? null;
+  const headerAvatarUrl = headerAvatarMappedUrls[0] ?? null;
   const headerOtherUserName = conversation?.otherUser?.name ?? 'User';
   const headerConversationTitle = conversation?.otherUser?.name ?? 'Conversation';
   const headerListingTitle =
@@ -320,13 +318,12 @@ export default function ConversationDetailScreen() {
       />
 
       <View style={styles.headerCard}>
-        {headerThumbnailUrl ? (
-          <Image source={{ uri: headerThumbnailUrl }} style={styles.headerThumbnail} />
-        ) : (
-          <View style={[styles.headerThumbnail, styles.thumbnailPlaceholder]}>
-            <Text style={styles.thumbnailPlaceholderText}>No image</Text>
-          </View>
-        )}
+        <ProfileAvatar
+          uri={headerAvatarUrl}
+          name={headerOtherUserName}
+          size={64}
+          style={styles.headerThumbnail}
+        />
         <View style={styles.headerTextWrap}>
           <Text style={styles.headerName} numberOfLines={1}>
             {headerOtherUserName}
@@ -478,18 +475,7 @@ const styles = StyleSheet.create({
   headerThumbnail: {
     width: 64,
     height: 64,
-    borderRadius: borderRadius.md,
-    backgroundColor: colors.border,
-  },
-  thumbnailPlaceholder: {
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  thumbnailPlaceholderText: {
-    ...typography.footnote,
-    fontSize: 10,
-    color: colors.muted,
-    fontWeight: '600',
+    borderRadius: 32,
   },
   headerTextWrap: {
     flex: 1,

--- a/frontend/app/conversations/[id].tsx
+++ b/frontend/app/conversations/[id].tsx
@@ -318,12 +318,7 @@ export default function ConversationDetailScreen() {
       />
 
       <View style={styles.headerCard}>
-        <ProfileAvatar
-          uri={headerAvatarUrl}
-          name={headerOtherUserName}
-          size={64}
-          style={styles.headerThumbnail}
-        />
+        <ProfileAvatar uri={headerAvatarUrl} name={headerOtherUserName} size={64} />
         <View style={styles.headerTextWrap}>
           <Text style={styles.headerName} numberOfLines={1}>
             {headerOtherUserName}
@@ -471,11 +466,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.lg,
-  },
-  headerThumbnail: {
-    width: 64,
-    height: 64,
-    borderRadius: 32,
   },
   headerTextWrap: {
     flex: 1,

--- a/frontend/app/conversations/new.tsx
+++ b/frontend/app/conversations/new.tsx
@@ -15,6 +15,8 @@ import { useAction, useQuery } from 'convex/react';
 import { api } from 'convex/_generated/api';
 import { Id } from 'convex/_generated/dataModel';
 import { useAuth } from '../../hooks/useAuth';
+import { useResolvedImageUrls } from '../../hooks/useResolvedImageUrls';
+import ProfileAvatar from '../../components/ProfileAvatar';
 import { ScreenState } from '../../components/ScreenState';
 import { colors, typography, spacing, borderRadius } from '../../theme/tokens';
 
@@ -37,6 +39,10 @@ export default function NewConversationScreen() {
     api.profiles.getProfileByUserId,
     listing?.sellerId ? { userId: listing.sellerId } : 'skip'
   );
+  const { mappedUrls: sellerAvatarUrls } = useResolvedImageUrls(
+    sellerProfile?.picture ? [sellerProfile.picture] : []
+  );
+  const sellerAvatarUrl = sellerAvatarUrls[0] ?? null;
 
   const [messageBody, setMessageBody] = useState('');
   const [isSending, setIsSending] = useState(false);
@@ -118,6 +124,15 @@ export default function NewConversationScreen() {
       />
 
       <View style={styles.content}>
+        <View style={styles.sellerRow}>
+          <ProfileAvatar uri={sellerAvatarUrl} name={sellerName} size={48} style={styles.avatar} />
+          <View style={styles.sellerCopy}>
+            <Text style={styles.sellerName}>{sellerName}</Text>
+            <Text style={styles.sellerListing} numberOfLines={1}>
+              {listing.title}
+            </Text>
+          </View>
+        </View>
         <Text style={styles.prompt}>Send a message about &quot;{listing.title}&quot;</Text>
         <TextInput
           value={messageBody}
@@ -163,6 +178,35 @@ const styles = StyleSheet.create({
     flex: 1,
     padding: spacing.lg,
     gap: spacing.md,
+  },
+  sellerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.surface,
+    padding: spacing.md,
+  },
+  avatar: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+  },
+  sellerCopy: {
+    flex: 1,
+    gap: 2,
+    minWidth: 0,
+  },
+  sellerName: {
+    ...typography.subhead,
+    color: colors.textDark,
+    fontWeight: '700',
+  },
+  sellerListing: {
+    ...typography.footnote,
+    color: colors.text,
   },
   prompt: {
     ...typography.subhead,

--- a/frontend/app/conversations/new.tsx
+++ b/frontend/app/conversations/new.tsx
@@ -125,7 +125,7 @@ export default function NewConversationScreen() {
 
       <View style={styles.content}>
         <View style={styles.sellerRow}>
-          <ProfileAvatar uri={sellerAvatarUrl} name={sellerName} size={48} style={styles.avatar} />
+          <ProfileAvatar uri={sellerAvatarUrl} name={sellerName} size={48} />
           <View style={styles.sellerCopy}>
             <Text style={styles.sellerName}>{sellerName}</Text>
             <Text style={styles.sellerListing} numberOfLines={1}>
@@ -188,11 +188,6 @@ const styles = StyleSheet.create({
     borderRadius: borderRadius.md,
     backgroundColor: colors.surface,
     padding: spacing.md,
-  },
-  avatar: {
-    width: 48,
-    height: 48,
-    borderRadius: 24,
   },
   sellerCopy: {
     flex: 1,

--- a/frontend/app/listings/[id].tsx
+++ b/frontend/app/listings/[id].tsx
@@ -503,7 +503,7 @@ export default function ListingDetailScreen() {
             <ProfileAvatar
               uri={sellerAvatarUrl}
               name={sellerProfile.name}
-              size={42}
+              size={44}
               style={styles.sellerAvatar}
               textStyle={styles.sellerAvatarText}
             />

--- a/frontend/app/listings/[id].tsx
+++ b/frontend/app/listings/[id].tsx
@@ -29,6 +29,7 @@ import { useFlash } from '../../contexts/FlashContext';
 import { useAuth } from '../../hooks/useAuth';
 import HiddenBanner from '../../components/HiddenBanner';
 import ListingUnavailable from '../../components/ListingUnavailable';
+import ProfileAvatar from '../../components/ProfileAvatar';
 import { ScreenState } from '../../components/ScreenState';
 import { ReportModal } from '../../components/ReportModal';
 import { useEntranceAnimation } from '../../hooks/useEntranceAnimation';
@@ -106,6 +107,10 @@ export default function ListingDetailScreen() {
     api.profiles.getProfileByUserId,
     listing?.sellerId ? { userId: listing.sellerId } : 'skip'
   );
+  const { mappedUrls: sellerAvatarUrls } = useResolvedImageUrls(
+    sellerProfile?.picture ? [sellerProfile.picture] : []
+  );
+  const sellerAvatarUrl = sellerAvatarUrls[0] ?? null;
   const hasMultipleImages = mappedUrls.length > 1;
   const hasPreviousImage = imageIndex > 0;
   const hasNextImage = imageIndex < mappedUrls.length - 1;
@@ -495,11 +500,13 @@ export default function ListingDetailScreen() {
             accessibilityLabel={`View ${sellerProfile.name}'s profile`}
             accessibilityRole="button"
           >
-            <View style={[styles.sellerAvatar, styles.sellerAvatarPlaceholder]}>
-              <Text style={styles.sellerAvatarText}>
-                {sellerProfile.name.charAt(0).toUpperCase()}
-              </Text>
-            </View>
+            <ProfileAvatar
+              uri={sellerAvatarUrl}
+              name={sellerProfile.name}
+              size={42}
+              style={styles.sellerAvatar}
+              textStyle={styles.sellerAvatarText}
+            />
             <View style={styles.sellerInfo}>
               <Text style={styles.sellerName}>{sellerProfile.name}</Text>
               <Text style={styles.sellerMeta}>
@@ -806,11 +813,6 @@ const styles = StyleSheet.create({
     height: 44,
     borderRadius: 22,
     backgroundColor: colors.border,
-  },
-  sellerAvatarPlaceholder: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: colors.location,
   },
   sellerAvatarText: {
     ...typography.subhead,

--- a/frontend/app/profile/[userId].tsx
+++ b/frontend/app/profile/[userId].tsx
@@ -1,12 +1,4 @@
-import {
-  Image,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  View,
-  useWindowDimensions,
-} from 'react-native';
+import { Pressable, ScrollView, StyleSheet, Text, View, useWindowDimensions } from 'react-native';
 import { useState } from 'react';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useQuery } from 'convex/react';
@@ -16,6 +8,7 @@ import { useFlash } from '../../contexts/FlashContext';
 import { useAuth } from '../../hooks/useAuth';
 import { useResolvedImageUrls } from '../../hooks/useResolvedImageUrls';
 import ListingCard from '../../components/ListingCard';
+import ProfileAvatar from '../../components/ProfileAvatar';
 import { ReportModal } from '../../components/ReportModal';
 import { ScreenState } from '../../components/ScreenState';
 import { REPORT_SUBMITTED_MESSAGE } from '../../constants/feedbackMessages';
@@ -103,15 +96,7 @@ export default function PublicProfileScreen() {
     >
       <View style={styles.profileCard}>
         <View style={styles.profileHeader}>
-          {avatarUrl ? (
-            <Image source={{ uri: avatarUrl }} style={styles.avatar} />
-          ) : (
-            <View style={[styles.avatar, styles.avatarPlaceholder]}>
-              <Text style={styles.avatarPlaceholderText}>
-                {profile.name.charAt(0).toUpperCase()}
-              </Text>
-            </View>
-          )}
+          <ProfileAvatar uri={avatarUrl} name={profile.name} size={72} style={styles.avatar} />
           <View style={styles.profileInfo}>
             <Text style={styles.profileName}>{profile.name}</Text>
             <Text style={styles.profileMeta}>
@@ -195,14 +180,6 @@ const styles = StyleSheet.create({
     height: 72,
     borderRadius: 36,
     backgroundColor: colors.border,
-  },
-  avatarPlaceholder: {
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  avatarPlaceholderText: {
-    ...typography.title1,
-    color: colors.primary,
   },
   profileInfo: {
     flex: 1,

--- a/frontend/app/profile/[userId].tsx
+++ b/frontend/app/profile/[userId].tsx
@@ -96,7 +96,7 @@ export default function PublicProfileScreen() {
     >
       <View style={styles.profileCard}>
         <View style={styles.profileHeader}>
-          <ProfileAvatar uri={avatarUrl} name={profile.name} size={72} style={styles.avatar} />
+          <ProfileAvatar uri={avatarUrl} name={profile.name} size={72} />
           <View style={styles.profileInfo}>
             <Text style={styles.profileName}>{profile.name}</Text>
             <Text style={styles.profileMeta}>
@@ -174,12 +174,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.lg,
-  },
-  avatar: {
-    width: 72,
-    height: 72,
-    borderRadius: 36,
-    backgroundColor: colors.border,
   },
   profileInfo: {
     flex: 1,

--- a/frontend/app/profile/edit.tsx
+++ b/frontend/app/profile/edit.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
+  Image,
   Pressable,
   StyleSheet,
   Text,
@@ -11,15 +12,54 @@ import {
 import { useRouter } from 'expo-router';
 import { useMutation, useQuery } from 'convex/react';
 import { api } from 'convex/_generated/api';
+import { Id } from 'convex/_generated/dataModel';
+import * as ImagePicker from 'expo-image-picker';
+import { SaveFormat, manipulateAsync } from 'expo-image-manipulator';
 import { getEmailValidationError } from '@polybuys/shared';
 import { useAuth } from '../../hooks/useAuth';
+import ProfileAvatar from '../../components/ProfileAvatar';
 import { KeyboardAwareScreen } from '../../components/ui';
+import { useResolvedImageUrls } from '../../hooks/useResolvedImageUrls';
 import { colors, typography, spacing, borderRadius } from '../../theme/tokens';
 
 const BOUNDS = {
   MIN_YEAR: 1900,
   MAX_YEAR: 9999,
 };
+const DEFAULT_YEAR = '2026';
+const PROFILE_IMAGE_BOUNDS = {
+  MAX_WIDTH: 1200,
+  MAX_FILE_SIZE_MB: 5,
+};
+
+async function uploadImageToConvex(uploadUrl: string, blob: Blob): Promise<Id<'_storage'>> {
+  return await new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', uploadUrl);
+    xhr.setRequestHeader('Content-Type', blob.type || 'image/jpeg');
+
+    xhr.onerror = () => reject(new Error('Network error during image upload.'));
+    xhr.onload = () => {
+      if (xhr.status < 200 || xhr.status >= 300) {
+        reject(new Error(`Image upload failed (${xhr.status}).`));
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(xhr.responseText) as { storageId?: Id<'_storage'> };
+        if (!parsed.storageId) {
+          reject(new Error('Upload response missing storage ID.'));
+          return;
+        }
+        resolve(parsed.storageId);
+      } catch {
+        reject(new Error('Upload response could not be parsed.'));
+      }
+    };
+
+    xhr.send(blob);
+  });
+}
 
 export default function ProfileEditScreen() {
   const router = useRouter();
@@ -27,14 +67,20 @@ export default function ProfileEditScreen() {
   const profile = useQuery(api.profiles.getCurrentProfile, isAuthenticated ? {} : 'skip');
   const createProfile = useMutation(api.profiles.createProfile);
   const updateProfile = useMutation(api.profiles.updateProfile);
+  const generateUploadUrl = useMutation(api.profiles.generateUploadUrl);
 
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [bio, setBio] = useState('');
   const [major, setMajor] = useState('');
-  const [year, setYear] = useState('2026');
+  const [year, setYear] = useState(DEFAULT_YEAR);
+  const [picture, setPicture] = useState<Id<'_storage'> | null>(null);
+  const [picturePreviewUri, setPicturePreviewUri] = useState<string | null>(null);
+  const [isUploadingPicture, setIsUploadingPicture] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [loadedKey, setLoadedKey] = useState<string | null>(null);
+  const { mappedUrls: pictureUrls } = useResolvedImageUrls(picture ? [picture] : []);
+  const pictureUrl = picturePreviewUri ?? pictureUrls[0] ?? null;
 
   useEffect(() => {
     if (!isAuthenticated || profile === undefined) return;
@@ -48,10 +94,16 @@ export default function ProfileEditScreen() {
       setBio(profile.bio ?? '');
       setMajor(profile.major);
       setYear(String(profile.year));
+      setPicture(profile.picture ?? null);
     } else {
+      setName('');
+      setEmail('');
+      setBio('');
       setMajor('');
-      setYear('2026');
+      setYear(DEFAULT_YEAR);
+      setPicture(null);
     }
+    setPicturePreviewUri(null);
     setLoadedKey(key);
   }, [isAuthenticated, profile, loadedKey]);
 
@@ -60,6 +112,70 @@ export default function ProfileEditScreen() {
       router.replace('/auth/login?returnTo=%2Fprofile%2Fedit' as never);
     }
   }, [isAuthenticated, router]);
+
+  const handlePickPicture = async () => {
+    if (isUploadingPicture || isSubmitting) {
+      return;
+    }
+
+    try {
+      const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (!permission.granted) {
+        Alert.alert('Permission required', 'Please allow photo library access to upload a photo.');
+        return;
+      }
+
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ['images'],
+        quality: 1,
+        allowsEditing: true,
+        aspect: [1, 1],
+      });
+      if (result.canceled) {
+        return;
+      }
+
+      setIsUploadingPicture(true);
+      const picked = result.assets[0];
+
+      // Re-encode first to apply EXIF orientation so landscape photos do not appear rotated.
+      const normalized = await manipulateAsync(picked.uri, [], {
+        compress: 1,
+        format: SaveFormat.JPEG,
+      });
+      const resizeActions =
+        normalized.width > PROFILE_IMAGE_BOUNDS.MAX_WIDTH
+          ? [{ resize: { width: PROFILE_IMAGE_BOUNDS.MAX_WIDTH } }]
+          : [];
+      const manipulated = await manipulateAsync(normalized.uri, resizeActions, {
+        compress: 0.8,
+        format: SaveFormat.JPEG,
+      });
+
+      const blob = await (await fetch(manipulated.uri)).blob();
+      const maxBytes = PROFILE_IMAGE_BOUNDS.MAX_FILE_SIZE_MB * 1024 * 1024;
+      if (blob.size > maxBytes) {
+        throw new Error(
+          `Profile image is too large after compression (max ${PROFILE_IMAGE_BOUNDS.MAX_FILE_SIZE_MB} MB).`
+        );
+      }
+
+      const uploadUrl = await generateUploadUrl({});
+      const storageId = await uploadImageToConvex(uploadUrl, blob);
+      setPicture(storageId);
+      setPicturePreviewUri(manipulated.uri);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to upload profile image';
+      Alert.alert('Upload failed', message);
+    } finally {
+      setIsUploadingPicture(false);
+    }
+  };
+
+  const handleRemovePicture = () => {
+    setPicture(null);
+    setPicturePreviewUri(null);
+  };
 
   const handleSave = async () => {
     const trimmedName = name.trim();
@@ -103,6 +219,7 @@ export default function ProfileEditScreen() {
           name: trimmedName,
           email: normalizedEmail,
           bio: trimmedBio || undefined,
+          picture: picture ?? undefined,
           major: trimmedMajor,
           year: parsedYear,
         });
@@ -111,6 +228,7 @@ export default function ProfileEditScreen() {
           name: trimmedName,
           email: normalizedEmail,
           bio: trimmedBio || undefined,
+          picture: picture === null ? null : picture,
           major: trimmedMajor,
           year: parsedYear,
         });
@@ -137,6 +255,52 @@ export default function ProfileEditScreen() {
 
   return (
     <KeyboardAwareScreen style={styles.container} contentContainerStyle={styles.content}>
+      <View style={styles.field}>
+        <Text style={styles.label}>Profile picture</Text>
+        <View style={styles.pictureRow}>
+          {pictureUrl ? (
+            <Image source={{ uri: pictureUrl }} style={styles.avatar} />
+          ) : (
+            <ProfileAvatar name={name} size={84} style={styles.avatar} />
+          )}
+          <View style={styles.pictureActions}>
+            <Pressable
+              style={({ pressed }) => [
+                styles.pictureButton,
+                pressed && styles.buttonPressed,
+                isUploadingPicture && styles.buttonDisabled,
+              ]}
+              onPress={() => void handlePickPicture()}
+              disabled={isUploadingPicture || isSubmitting}
+              accessibilityRole="button"
+              accessibilityLabel={picture ? 'Change profile picture' : 'Add profile picture'}
+            >
+              {isUploadingPicture ? (
+                <ActivityIndicator color={colors.primary} size="small" />
+              ) : (
+                <Text style={styles.pictureButtonText}>
+                  {picture ? 'Change photo' : 'Upload photo'}
+                </Text>
+              )}
+            </Pressable>
+            {picture ? (
+              <Pressable
+                onPress={handleRemovePicture}
+                disabled={isUploadingPicture || isSubmitting}
+                style={({ pressed }) => [
+                  styles.removeButton,
+                  pressed && styles.buttonPressed,
+                  (isUploadingPicture || isSubmitting) && styles.buttonDisabled,
+                ]}
+                accessibilityRole="button"
+                accessibilityLabel="Remove profile picture"
+              >
+                <Text style={styles.removeButtonText}>Remove photo</Text>
+              </Pressable>
+            ) : null}
+          </View>
+        </View>
+      </View>
       <View style={styles.field}>
         <Text style={styles.label}>Name *</Text>
         <TextInput
@@ -207,10 +371,10 @@ export default function ProfileEditScreen() {
         style={({ pressed }) => [
           styles.saveButton,
           pressed && styles.buttonPressed,
-          isSubmitting && styles.buttonDisabled,
+          (isSubmitting || isUploadingPicture) && styles.buttonDisabled,
         ]}
         onPress={() => void handleSave()}
-        disabled={isSubmitting}
+        disabled={isSubmitting || isUploadingPicture}
         accessibilityLabel={isSubmitting ? 'Saving profile' : 'Save profile'}
         accessibilityRole="button"
       >
@@ -242,6 +406,48 @@ const styles = StyleSheet.create({
   },
   field: {
     gap: spacing.xs,
+  },
+  pictureRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  pictureActions: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  avatar: {
+    width: 84,
+    height: 84,
+    borderRadius: 42,
+    backgroundColor: colors.border,
+  },
+  pictureButton: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+    borderRadius: borderRadius.md,
+    minHeight: 44,
+    paddingHorizontal: spacing.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    alignSelf: 'flex-start',
+  },
+  pictureButtonText: {
+    ...typography.footnoteMed,
+    color: colors.textDark,
+    fontWeight: '600',
+  },
+  removeButton: {
+    minHeight: 36,
+    alignSelf: 'flex-start',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xs,
+  },
+  removeButtonText: {
+    ...typography.footnote,
+    color: colors.destructive,
+    fontWeight: '600',
   },
   label: {
     ...typography.footnote,

--- a/frontend/app/profile/edit.tsx
+++ b/frontend/app/profile/edit.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
-  Image,
   Pressable,
   StyleSheet,
   Text,
@@ -20,6 +19,7 @@ import { useAuth } from '../../hooks/useAuth';
 import ProfileAvatar from '../../components/ProfileAvatar';
 import { KeyboardAwareScreen } from '../../components/ui';
 import { useResolvedImageUrls } from '../../hooks/useResolvedImageUrls';
+import { useFlash } from '../../contexts/FlashContext';
 import { colors, typography, spacing, borderRadius } from '../../theme/tokens';
 
 const BOUNDS = {
@@ -30,33 +30,82 @@ const DEFAULT_YEAR = '2026';
 const PROFILE_IMAGE_BOUNDS = {
   MAX_WIDTH: 1200,
   MAX_FILE_SIZE_MB: 5,
+  UPLOAD_TIMEOUT_MS: 20000,
 };
 
-async function uploadImageToConvex(uploadUrl: string, blob: Blob): Promise<Id<'_storage'>> {
+type UploadOptions = {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+};
+
+async function uploadImageToConvex(
+  uploadUrl: string,
+  blob: Blob,
+  { signal, timeoutMs = PROFILE_IMAGE_BOUNDS.UPLOAD_TIMEOUT_MS }: UploadOptions = {}
+): Promise<Id<'_storage'>> {
   return await new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
+    let settled = false;
+
+    const rejectOnce = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const resolveOnce = (value: Id<'_storage'>) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+    const onAbort = () => {
+      try {
+        xhr.abort();
+      } catch {
+        // no-op
+      }
+      rejectOnce(new Error('Image upload was cancelled.'));
+    };
+    const cleanup = () => {
+      xhr.onerror = null;
+      xhr.onload = null;
+      xhr.onabort = null;
+      xhr.ontimeout = null;
+      signal?.removeEventListener('abort', onAbort);
+    };
+
+    if (signal?.aborted) {
+      rejectOnce(new Error('Image upload was cancelled.'));
+      return;
+    }
+
     xhr.open('POST', uploadUrl);
+    xhr.timeout = timeoutMs;
     xhr.setRequestHeader('Content-Type', blob.type || 'image/jpeg');
 
-    xhr.onerror = () => reject(new Error('Network error during image upload.'));
+    xhr.onerror = () => rejectOnce(new Error('Network error during image upload.'));
+    xhr.onabort = () => rejectOnce(new Error('Image upload was cancelled.'));
+    xhr.ontimeout = () => rejectOnce(new Error('Image upload timed out. Please try again.'));
     xhr.onload = () => {
       if (xhr.status < 200 || xhr.status >= 300) {
-        reject(new Error(`Image upload failed (${xhr.status}).`));
+        rejectOnce(new Error(`Image upload failed (${xhr.status}).`));
         return;
       }
 
       try {
         const parsed = JSON.parse(xhr.responseText) as { storageId?: Id<'_storage'> };
         if (!parsed.storageId) {
-          reject(new Error('Upload response missing storage ID.'));
+          rejectOnce(new Error('Upload response missing storage ID.'));
           return;
         }
-        resolve(parsed.storageId);
+        resolveOnce(parsed.storageId);
       } catch {
-        reject(new Error('Upload response could not be parsed.'));
+        rejectOnce(new Error('Upload response could not be parsed.'));
       }
     };
 
+    signal?.addEventListener('abort', onAbort, { once: true });
     xhr.send(blob);
   });
 }
@@ -64,10 +113,12 @@ async function uploadImageToConvex(uploadUrl: string, blob: Blob): Promise<Id<'_
 export default function ProfileEditScreen() {
   const router = useRouter();
   const { isAuthenticated } = useAuth();
+  const { setFlash } = useFlash();
   const profile = useQuery(api.profiles.getCurrentProfile, isAuthenticated ? {} : 'skip');
   const createProfile = useMutation(api.profiles.createProfile);
   const updateProfile = useMutation(api.profiles.updateProfile);
   const generateUploadUrl = useMutation(api.profiles.generateUploadUrl);
+  const uploadAbortRef = useRef<AbortController | null>(null);
 
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -75,12 +126,12 @@ export default function ProfileEditScreen() {
   const [major, setMajor] = useState('');
   const [year, setYear] = useState(DEFAULT_YEAR);
   const [picture, setPicture] = useState<Id<'_storage'> | null>(null);
-  const [picturePreviewUri, setPicturePreviewUri] = useState<string | null>(null);
-  const [isUploadingPicture, setIsUploadingPicture] = useState(false);
+  const [pendingPictureUri, setPendingPictureUri] = useState<string | null>(null);
+  const [isPreparingPicture, setIsPreparingPicture] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [loadedKey, setLoadedKey] = useState<string | null>(null);
   const { mappedUrls: pictureUrls } = useResolvedImageUrls(picture ? [picture] : []);
-  const pictureUrl = picturePreviewUri ?? pictureUrls[0] ?? null;
+  const pictureUrl = pendingPictureUri ?? pictureUrls[0] ?? null;
 
   useEffect(() => {
     if (!isAuthenticated || profile === undefined) return;
@@ -103,7 +154,7 @@ export default function ProfileEditScreen() {
       setYear(DEFAULT_YEAR);
       setPicture(null);
     }
-    setPicturePreviewUri(null);
+    setPendingPictureUri(null);
     setLoadedKey(key);
   }, [isAuthenticated, profile, loadedKey]);
 
@@ -113,15 +164,22 @@ export default function ProfileEditScreen() {
     }
   }, [isAuthenticated, router]);
 
+  useEffect(() => {
+    return () => {
+      uploadAbortRef.current?.abort();
+      uploadAbortRef.current = null;
+    };
+  }, []);
+
   const handlePickPicture = async () => {
-    if (isUploadingPicture || isSubmitting) {
+    if (isPreparingPicture || isSubmitting) {
       return;
     }
 
     try {
       const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
       if (!permission.granted) {
-        Alert.alert('Permission required', 'Please allow photo library access to upload a photo.');
+        setFlash('Photo library permission is required to upload a profile picture.');
         return;
       }
 
@@ -135,7 +193,7 @@ export default function ProfileEditScreen() {
         return;
       }
 
-      setIsUploadingPicture(true);
+      setIsPreparingPicture(true);
       const picked = result.assets[0];
 
       // Re-encode first to apply EXIF orientation so landscape photos do not appear rotated.
@@ -160,21 +218,18 @@ export default function ProfileEditScreen() {
         );
       }
 
-      const uploadUrl = await generateUploadUrl({});
-      const storageId = await uploadImageToConvex(uploadUrl, blob);
-      setPicture(storageId);
-      setPicturePreviewUri(manipulated.uri);
+      setPendingPictureUri(manipulated.uri);
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to upload profile image';
-      Alert.alert('Upload failed', message);
+      const message = error instanceof Error ? error.message : 'Failed to prepare profile image';
+      setFlash(message);
     } finally {
-      setIsUploadingPicture(false);
+      setIsPreparingPicture(false);
     }
   };
 
   const handleRemovePicture = () => {
     setPicture(null);
-    setPicturePreviewUri(null);
+    setPendingPictureUri(null);
   };
 
   const handleSave = async () => {
@@ -184,17 +239,17 @@ export default function ProfileEditScreen() {
     const normalizedEmail = email.trim().toLowerCase();
 
     if (!trimmedName) {
-      Alert.alert('Missing field', 'Name is required.');
+      setFlash('Name is required.');
       return;
     }
     if (!trimmedMajor) {
-      Alert.alert('Missing field', 'Major is required.');
+      setFlash('Major is required.');
       return;
     }
 
     const emailError = getEmailValidationError(normalizedEmail);
     if (emailError) {
-      Alert.alert('Invalid email', emailError);
+      setFlash(emailError);
       return;
     }
 
@@ -204,22 +259,32 @@ export default function ProfileEditScreen() {
       parsedYear < BOUNDS.MIN_YEAR ||
       parsedYear > BOUNDS.MAX_YEAR
     ) {
-      Alert.alert(
-        'Invalid year',
-        `Year must be between ${BOUNDS.MIN_YEAR} and ${BOUNDS.MAX_YEAR}.`
-      );
+      setFlash(`Year must be between ${BOUNDS.MIN_YEAR} and ${BOUNDS.MAX_YEAR}.`);
       return;
     }
 
     try {
       setIsSubmitting(true);
+      let nextPicture: Id<'_storage'> | null = picture;
+
+      if (pendingPictureUri) {
+        const blob = await (await fetch(pendingPictureUri)).blob();
+        const uploadUrl = await generateUploadUrl({});
+        uploadAbortRef.current?.abort();
+        const abortController = new AbortController();
+        uploadAbortRef.current = abortController;
+        nextPicture = await uploadImageToConvex(uploadUrl, blob, {
+          signal: abortController.signal,
+        });
+        uploadAbortRef.current = null;
+      }
 
       if (!profile) {
         await createProfile({
           name: trimmedName,
           email: normalizedEmail,
           bio: trimmedBio || undefined,
-          picture: picture ?? undefined,
+          picture: nextPicture ?? undefined,
           major: trimmedMajor,
           year: parsedYear,
         });
@@ -228,18 +293,21 @@ export default function ProfileEditScreen() {
           name: trimmedName,
           email: normalizedEmail,
           bio: trimmedBio || undefined,
-          picture: picture === null ? null : picture,
+          picture: nextPicture,
           major: trimmedMajor,
           year: parsedYear,
         });
       }
 
+      setPicture(nextPicture);
+      setPendingPictureUri(null);
       Alert.alert('Profile saved', 'Your profile has been updated.', [
         { text: 'OK', onPress: () => router.back() },
       ]);
     } catch (error) {
+      uploadAbortRef.current = null;
       const message = error instanceof Error ? error.message : 'Failed to save profile';
-      Alert.alert('Save failed', message);
+      setFlash(message);
     } finally {
       setIsSubmitting(false);
     }
@@ -258,39 +326,35 @@ export default function ProfileEditScreen() {
       <View style={styles.field}>
         <Text style={styles.label}>Profile picture</Text>
         <View style={styles.pictureRow}>
-          {pictureUrl ? (
-            <Image source={{ uri: pictureUrl }} style={styles.avatar} />
-          ) : (
-            <ProfileAvatar name={name} size={84} style={styles.avatar} />
-          )}
+          <ProfileAvatar uri={pictureUrl} name={name} size={84} style={styles.avatar} />
           <View style={styles.pictureActions}>
             <Pressable
               style={({ pressed }) => [
                 styles.pictureButton,
                 pressed && styles.buttonPressed,
-                isUploadingPicture && styles.buttonDisabled,
+                isPreparingPicture && styles.buttonDisabled,
               ]}
               onPress={() => void handlePickPicture()}
-              disabled={isUploadingPicture || isSubmitting}
+              disabled={isPreparingPicture || isSubmitting}
               accessibilityRole="button"
-              accessibilityLabel={picture ? 'Change profile picture' : 'Add profile picture'}
+              accessibilityLabel={pictureUrl ? 'Change profile picture' : 'Add profile picture'}
             >
-              {isUploadingPicture ? (
+              {isPreparingPicture ? (
                 <ActivityIndicator color={colors.primary} size="small" />
               ) : (
                 <Text style={styles.pictureButtonText}>
-                  {picture ? 'Change photo' : 'Upload photo'}
+                  {pictureUrl ? 'Change photo' : 'Upload photo'}
                 </Text>
               )}
             </Pressable>
-            {picture ? (
+            {pictureUrl ? (
               <Pressable
                 onPress={handleRemovePicture}
-                disabled={isUploadingPicture || isSubmitting}
+                disabled={isPreparingPicture || isSubmitting}
                 style={({ pressed }) => [
                   styles.removeButton,
                   pressed && styles.buttonPressed,
-                  (isUploadingPicture || isSubmitting) && styles.buttonDisabled,
+                  (isPreparingPicture || isSubmitting) && styles.buttonDisabled,
                 ]}
                 accessibilityRole="button"
                 accessibilityLabel="Remove profile picture"
@@ -371,10 +435,10 @@ export default function ProfileEditScreen() {
         style={({ pressed }) => [
           styles.saveButton,
           pressed && styles.buttonPressed,
-          (isSubmitting || isUploadingPicture) && styles.buttonDisabled,
+          (isSubmitting || isPreparingPicture) && styles.buttonDisabled,
         ]}
         onPress={() => void handleSave()}
-        disabled={isSubmitting || isUploadingPicture}
+        disabled={isSubmitting || isPreparingPicture}
         accessibilityLabel={isSubmitting ? 'Saving profile' : 'Save profile'}
         accessibilityRole="button"
       >
@@ -420,7 +484,6 @@ const styles = StyleSheet.create({
     width: 84,
     height: 84,
     borderRadius: 42,
-    backgroundColor: colors.border,
   },
   pictureButton: {
     borderWidth: 1,

--- a/frontend/components/ProfileAvatar.tsx
+++ b/frontend/components/ProfileAvatar.tsx
@@ -1,0 +1,85 @@
+import {
+  Image,
+  StyleSheet,
+  Text,
+  View,
+  type ImageStyle,
+  type StyleProp,
+  type TextStyle,
+  type ViewStyle,
+} from 'react-native';
+import { colors, typography } from '../theme/tokens';
+
+type ProfileAvatarProps = {
+  uri?: string | null;
+  name?: string | null;
+  size?: number;
+  style?: StyleProp<ViewStyle>;
+  textStyle?: StyleProp<TextStyle>;
+};
+
+export function getAvatarInitial(name?: string | null) {
+  const trimmed = name?.trim();
+  if (!trimmed) {
+    return '?';
+  }
+  return trimmed.charAt(0).toUpperCase();
+}
+
+export default function ProfileAvatar({
+  uri,
+  name,
+  size = 48,
+  style,
+  textStyle,
+}: ProfileAvatarProps) {
+  const imageStyle = style as StyleProp<ImageStyle>;
+  const initialFontSize = Math.max(14, Math.round(size * 0.42));
+  const avatarShape = {
+    width: size,
+    height: size,
+    borderRadius: size / 2,
+  };
+
+  if (uri) {
+    return <Image source={{ uri }} style={[styles.base, avatarShape, imageStyle]} />;
+  }
+
+  return (
+    <View style={[styles.base, styles.placeholder, avatarShape, style]}>
+      <Text
+        style={[
+          styles.initialText,
+          {
+            fontSize: initialFontSize,
+            lineHeight: Math.ceil(initialFontSize * 1.1),
+          },
+          textStyle,
+        ]}
+      >
+        {getAvatarInitial(name)}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  base: {
+    backgroundColor: colors.border,
+  },
+  placeholder: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.location,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  initialText: {
+    fontFamily: typography.heading.fontFamily,
+    color: colors.primary,
+    fontWeight: '700',
+    letterSpacing: 0,
+    textAlign: 'center',
+    includeFontPadding: false,
+  },
+});

--- a/frontend/components/ProfileAvatar.tsx
+++ b/frontend/components/ProfileAvatar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useState } from 'react';
 import {
   Image,
   StyleSheet,
@@ -23,7 +24,8 @@ export function getAvatarInitial(name?: string | null) {
   if (!trimmed) {
     return '?';
   }
-  return trimmed.charAt(0).toUpperCase();
+  const first = [...trimmed][0];
+  return first.toUpperCase();
 }
 
 export default function ProfileAvatar({
@@ -35,18 +37,39 @@ export default function ProfileAvatar({
 }: ProfileAvatarProps) {
   const imageStyle = style as StyleProp<ImageStyle>;
   const initialFontSize = Math.max(14, Math.round(size * 0.42));
+  const [imageError, setImageError] = useState(false);
   const avatarShape = {
     width: size,
     height: size,
     borderRadius: size / 2,
   };
+  const avatarLabel = useMemo(() => {
+    const trimmedName = name?.trim();
+    return trimmedName ? `${trimmedName}'s avatar` : 'User avatar';
+  }, [name]);
 
-  if (uri) {
-    return <Image source={{ uri }} style={[styles.base, avatarShape, imageStyle]} />;
+  useEffect(() => {
+    setImageError(false);
+  }, [uri]);
+
+  if (uri && !imageError) {
+    return (
+      <Image
+        source={{ uri }}
+        style={[styles.base, avatarShape, imageStyle]}
+        onError={() => setImageError(true)}
+        accessibilityLabel={avatarLabel}
+        accessibilityRole="image"
+      />
+    );
   }
 
   return (
-    <View style={[styles.base, styles.placeholder, avatarShape, style]}>
+    <View
+      style={[styles.base, styles.placeholder, avatarShape, style]}
+      accessibilityLabel={avatarLabel}
+      accessibilityRole="image"
+    >
       <Text
         style={[
           styles.initialText,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "@sentry/react-native": "^8.3.0",
     "convex": "^1.32.0",
     "expo": "~55.0.5",
-    "expo-blur": "^55.0.14",
+    "expo-blur": "~55.0.8",
     "expo-constants": "~55.0.7",
     "expo-dev-client": "~55.0.16",
     "expo-device": "~55.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "@sentry/react-native": "^8.3.0",
         "convex": "^1.32.0",
         "expo": "~55.0.5",
-        "expo-blur": "^55.0.14",
+        "expo-blur": "~55.0.8",
         "expo-constants": "~55.0.7",
         "expo-dev-client": "~55.0.16",
         "expo-device": "~55.0.9",


### PR DESCRIPTION
## Linked Issues

Closes #58
Linear: POLY-58

## Summary

Adds end-to-end profile picture support across the app.

- Users can upload, change, and remove their profile photo in Profile Edit.
- Added orientation normalization during upload so landscape photos do not save sideways.
- Added fallback avatar behavior when no image exists (initials / default avatar).
- Propagated avatar display to key identity surfaces:
  - Profile tab / settings
  - Public profile
  - Listing seller card
  - Inbox conversation rows
  - Conversation detail header
  - New conversation screen
- Backend updates:
  - `profiles.updateProfile` now supports clearing `picture` (`null`) and handles replacing/removing old storage images.
  - `messages.listUserConversations` now returns `otherUser.picture` for avatar rendering.
- Added shared `ProfileAvatar` component and fixed fallback initial clipping/alignment.
- Added missing `expo-blur` dependency used by merged UI screens.

## How to Test

Steps to verify locally:

- `npm run lint`
- `npm run typecheck`
- `npm test`
- Manual flow:
  1. `npm run dev:backend` (in terminal A)
  2. `npm run dev` (in terminal B)
3. Sign in and open `Profile -> Edit`.
4. Upload a profile image (including a landscape image), crop, and save.
5. Confirm the avatar appears in:
   - Settings/Profile tab
   - Public profile page
   - Listing detail seller block
   - Inbox rows
   - Conversation header
   - New conversation compose screen
6. Go back to `Profile -> Edit`, tap **Remove photo**, save.
7. Confirm fallback avatar appears properly

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Lint/tests pass locally (`npm run lint`)
- [ ] Docs updated (README/ADR/changelog if needed)
- [ ] Follows conventional commit format
- [ ] No merge conflicts with `dev`

## Screenshots / Demos

<img width="340" height="122" alt="image" src="https://github.com/user-attachments/assets/2eebed17-2aef-4d6c-9742-01aa5393d099" />
<img width="340" height="232" alt="image" src="https://github.com/user-attachments/assets/53b3747c-ed9d-49f1-930d-c9c062e4c880" />
<img width="309" height="569" alt="image" src="https://github.com/user-attachments/assets/02b5dcbe-b1e1-4932-b590-185edece31d6" />
<img width="382" height="773" alt="image" src="https://github.com/user-attachments/assets/651b787a-0389-4099-913b-ee2d6fd16c6e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now upload and manage profile pictures throughout the app
  * Profile pictures appear in conversations, inbox, seller profiles, and individual listings
  * Centralized avatar display with name-based fallback initials when images are unavailable

* **Bug Fixes**
  * Improved profile picture storage cleanup when updating or removing images

<!-- end of auto-generated comment: release notes by coderabbit.ai -->