### PR TITLE
Redirect users home

### DIFF
--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -74,7 +74,7 @@ export default function SettingsScreen() {
 
   useEffect(() => {
     if (!isWeb && !isSessionLoading && !isAuthenticated) {
-      router.replace('/auth/login?returnTo=%2Fsettings' as never);
+      router.replace('/auth/login' as never);
     }
   }, [isAuthenticated, isSessionLoading, isWeb, router]);
 

--- a/frontend/app/account-settings.tsx
+++ b/frontend/app/account-settings.tsx
@@ -55,7 +55,7 @@ export default function AccountSettingsScreen() {
 
   useEffect(() => {
     if (!isWeb && !isLoading && !isAuthenticated) {
-      router.replace('/auth/login?returnTo=%2Faccount-settings' as never);
+      router.replace('/auth/login' as never);
     }
   }, [isAuthenticated, isLoading, isWeb, router]);
 
@@ -67,7 +67,7 @@ export default function AccountSettingsScreen() {
 
   const handleSignOut = async () => {
     if (!isAuthenticated) {
-      router.replace('/auth/login?returnTo=%2Faccount-settings' as never);
+      router.replace('/auth/login' as never);
       return;
     }
 

--- a/frontend/app/auth/login.tsx
+++ b/frontend/app/auth/login.tsx
@@ -66,6 +66,11 @@ export default function LoginScreen() {
     !normalizedReturnTo.startsWith('//')
       ? (normalizedReturnTo as Href)
       : '/';
+  const [successRedirect, setSuccessRedirect] = useState<Href>(postAuthRedirect);
+
+  useEffect(() => {
+    setSuccessRedirect(postAuthRedirect);
+  }, [postAuthRedirect]);
 
   useEffect(() => {
     const entryAction = getLoginEntryAction({
@@ -104,6 +109,7 @@ export default function LoginScreen() {
     }
 
     if (currentProfile) {
+      setSuccessRedirect(postAuthRedirect);
       setStep('success');
       return;
     }
@@ -113,17 +119,17 @@ export default function LoginScreen() {
     }
 
     setStep('profile');
-  }, [step, currentProfile, isSessionLoading, isAuthenticated]);
+  }, [step, currentProfile, isSessionLoading, isAuthenticated, postAuthRedirect]);
 
   useEffect(() => {
     if (step !== 'success') {
       return;
     }
     const t = setTimeout(() => {
-      router.replace(postAuthRedirect);
+      router.replace(successRedirect);
     }, 1500);
     return () => clearTimeout(t);
-  }, [step, postAuthRedirect, router]);
+  }, [step, successRedirect, router]);
 
   const handleCheckingRetry = useCallback(() => {
     if (retryTimerRef.current !== null) {
@@ -356,6 +362,7 @@ export default function LoginScreen() {
   }
 
   const finishAndRedirect = () => {
+    setSuccessRedirect('/');
     setStep('success');
   };
 


### PR DESCRIPTION
## Linked Issues

Closes #POLY-85
Linear: POLY-85

## Summary

Fixed auth redirect behavior so signing in from signed-out Profile/Settings flows no longer bounces users back into settings pages.

What changed:

frontend/app/(tabs)/settings.tsx: signed-out redirect now goes to /auth/login (removed returnTo=/settings).
frontend/app/account-settings.tsx: signed-out redirects now go to /auth/login (removed returnTo=/account-settings in both effect + sign-out handler).
frontend/app/auth/login.tsx: onboarding completion continues to force redirect to Home (/) after notification step; existing-user login still uses the appropriate post-auth redirect target.

## How to Test

Steps to verify locally:

- `npm run lint`
- `npm run typecheck`
- `npm test`
- Manual flow:
  1. `npm run dev:backend` (in terminal A)
  2. `npm run dev` (in terminal B)
  3. Verify the change: <describe expected behavior/screens>

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Lint/tests pass locally (`npm run lint`)
- [ ] Docs updated (README/ADR/changelog if needed)
- [ ] Follows conventional commit format
- [ ] No merge conflicts with `dev`

## Screenshots / Demos
