### PR TITLE
feat: add zoom support to listing photos

### DIFF
--- a/frontend/components/ImageLightbox.tsx
+++ b/frontend/components/ImageLightbox.tsx
@@ -77,8 +77,8 @@ export default function ImageLightbox({
     const frameHeight = screenHeight * 0.85;
     const limit =
       axis === 'x'
-        ? ((frameWidth * scale) - frameWidth) / 2
-        : ((frameHeight * scale) - frameHeight) / 2;
+        ? (frameWidth * scale - frameWidth) / 2
+        : (frameHeight * scale - frameHeight) / 2;
 
     if (limit <= 0) {
       return 0;
@@ -233,6 +233,8 @@ export default function ImageLightbox({
     if (visible) {
       setCurrentIndex(initialIndex);
       resetZoom();
+    } else {
+      resetZoom();
     }
   }, [visible, initialIndex, resetZoom]);
 
@@ -378,7 +380,10 @@ export default function ImageLightbox({
       )}
 
       {Platform.OS !== 'web' && (
-        <View style={[styles.zoomHint, { top: Math.max(insets.top + 64, 76) }]}>
+        <View
+          pointerEvents="none"
+          style={[styles.zoomHint, { top: Math.max(insets.top + 64, 76) }]}
+        >
           <Text style={styles.zoomHintText}>
             {isZoomed ? 'Drag to inspect details' : 'Pinch to zoom'}
           </Text>

--- a/frontend/components/ImageLightbox.tsx
+++ b/frontend/components/ImageLightbox.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Animated,
-  Image,
   Modal,
   Platform,
   Pressable,
@@ -46,7 +45,7 @@ export default function ImageLightbox({
   const minScale = 1;
   const maxScale = 4;
 
-  const resetZoom = () => {
+  const resetZoom = useCallback(() => {
     scaleRef.current = 1;
     translateRef.current = { x: 0, y: 0 };
     setIsZoomed(false);
@@ -67,7 +66,7 @@ export default function ImageLightbox({
         bounciness: 0,
       }),
     ]).start();
-  };
+  }, [imageScale, imageTranslateX, imageTranslateY]);
 
   const clampTranslate = (value: number, axis: 'x' | 'y', scale: number) => {
     if (scale <= minScale) {
@@ -235,11 +234,11 @@ export default function ImageLightbox({
       setCurrentIndex(initialIndex);
       resetZoom();
     }
-  }, [visible, initialIndex]);
+  }, [visible, initialIndex, resetZoom]);
 
   useEffect(() => {
     resetZoom();
-  }, [currentIndex]);
+  }, [currentIndex, resetZoom]);
 
   useEffect(() => {
     if (visible && Platform.OS === 'web') {

--- a/frontend/components/ImageLightbox.tsx
+++ b/frontend/components/ImageLightbox.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 import {
+  Animated,
   Image,
   Modal,
   Platform,
   Pressable,
   StyleSheet,
+  type GestureResponderEvent,
   Text,
   View,
   useWindowDimensions,
@@ -26,15 +28,218 @@ export default function ImageLightbox({
   onClose,
 }: ImageLightboxProps) {
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
+  const [isZoomed, setIsZoomed] = useState(false);
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
   const insets = useSafeAreaInsets();
   const overlayRef = useRef<HTMLDivElement | null>(null);
+  const imageScale = useRef(new Animated.Value(1)).current;
+  const imageTranslateX = useRef(new Animated.Value(0)).current;
+  const imageTranslateY = useRef(new Animated.Value(0)).current;
+  const scaleRef = useRef(1);
+  const translateRef = useRef({ x: 0, y: 0 });
+  const gestureStartScale = useRef(1);
+  const gestureStartTranslate = useRef({ x: 0, y: 0 });
+  const pinchStartDistance = useRef(0);
+  const activeGesture = useRef<'none' | 'pan' | 'pinch'>('none');
+  const panStartPoint = useRef({ x: 0, y: 0 });
+
+  const minScale = 1;
+  const maxScale = 4;
+
+  const resetZoom = () => {
+    scaleRef.current = 1;
+    translateRef.current = { x: 0, y: 0 };
+    setIsZoomed(false);
+    Animated.parallel([
+      Animated.spring(imageScale, {
+        toValue: 1,
+        useNativeDriver: true,
+        bounciness: 0,
+      }),
+      Animated.spring(imageTranslateX, {
+        toValue: 0,
+        useNativeDriver: true,
+        bounciness: 0,
+      }),
+      Animated.spring(imageTranslateY, {
+        toValue: 0,
+        useNativeDriver: true,
+        bounciness: 0,
+      }),
+    ]).start();
+  };
+
+  const clampTranslate = (value: number, axis: 'x' | 'y', scale: number) => {
+    if (scale <= minScale) {
+      return 0;
+    }
+
+    const frameWidth = screenWidth * 0.9;
+    const frameHeight = screenHeight * 0.85;
+    const limit =
+      axis === 'x'
+        ? ((frameWidth * scale) - frameWidth) / 2
+        : ((frameHeight * scale) - frameHeight) / 2;
+
+    if (limit <= 0) {
+      return 0;
+    }
+
+    return Math.max(-limit, Math.min(limit, value));
+  };
+
+  const getTouchDistance = (touches: readonly { pageX: number; pageY: number }[]) => {
+    if (touches.length < 2) {
+      return 0;
+    }
+
+    const [first, second] = touches;
+    const dx = second.pageX - first.pageX;
+    const dy = second.pageY - first.pageY;
+    return Math.sqrt(dx * dx + dy * dy);
+  };
+
+  const finishGesture = () => {
+    activeGesture.current = 'none';
+
+    if (scaleRef.current <= 1.01) {
+      resetZoom();
+      return;
+    }
+
+    const clampedX = clampTranslate(translateRef.current.x, 'x', scaleRef.current);
+    const clampedY = clampTranslate(translateRef.current.y, 'y', scaleRef.current);
+    translateRef.current = { x: clampedX, y: clampedY };
+    setIsZoomed(true);
+    Animated.parallel([
+      Animated.spring(imageTranslateX, {
+        toValue: clampedX,
+        useNativeDriver: true,
+        bounciness: 0,
+      }),
+      Animated.spring(imageTranslateY, {
+        toValue: clampedY,
+        useNativeDriver: true,
+        bounciness: 0,
+      }),
+    ]).start();
+  };
+
+  const handleTouchStart = (event: GestureResponderEvent) => {
+    const touches = event.nativeEvent.touches;
+
+    if (touches.length >= 2) {
+      activeGesture.current = 'pinch';
+      gestureStartScale.current = scaleRef.current;
+      gestureStartTranslate.current = { ...translateRef.current };
+      pinchStartDistance.current = getTouchDistance(touches);
+      return;
+    }
+
+    if (touches.length === 1 && scaleRef.current > 1.01) {
+      activeGesture.current = 'pan';
+      gestureStartTranslate.current = { ...translateRef.current };
+      panStartPoint.current = {
+        x: touches[0].pageX,
+        y: touches[0].pageY,
+      };
+    }
+  };
+
+  const handleTouchMove = (event: GestureResponderEvent) => {
+    const touches = event.nativeEvent.touches;
+
+    if (touches.length >= 2) {
+      if (activeGesture.current !== 'pinch') {
+        activeGesture.current = 'pinch';
+        gestureStartScale.current = scaleRef.current;
+        gestureStartTranslate.current = { ...translateRef.current };
+        pinchStartDistance.current = getTouchDistance(touches);
+      }
+
+      const distance = getTouchDistance(touches);
+      if (pinchStartDistance.current <= 0 || distance <= 0) {
+        return;
+      }
+
+      const nextScale = Math.max(
+        minScale,
+        Math.min(maxScale, gestureStartScale.current * (distance / pinchStartDistance.current))
+      );
+
+      scaleRef.current = nextScale;
+      setIsZoomed(nextScale > 1.01);
+      imageScale.setValue(nextScale);
+
+      const clampedX = clampTranslate(translateRef.current.x, 'x', nextScale);
+      const clampedY = clampTranslate(translateRef.current.y, 'y', nextScale);
+      translateRef.current = { x: clampedX, y: clampedY };
+      imageTranslateX.setValue(clampedX);
+      imageTranslateY.setValue(clampedY);
+      return;
+    }
+
+    if (touches.length === 1 && scaleRef.current > 1.01) {
+      if (activeGesture.current !== 'pan') {
+        activeGesture.current = 'pan';
+        gestureStartTranslate.current = { ...translateRef.current };
+        panStartPoint.current = {
+          x: touches[0].pageX,
+          y: touches[0].pageY,
+        };
+      }
+
+      const nextX = clampTranslate(
+        gestureStartTranslate.current.x + (touches[0].pageX - panStartPoint.current.x),
+        'x',
+        scaleRef.current
+      );
+      const nextY = clampTranslate(
+        gestureStartTranslate.current.y + (touches[0].pageY - panStartPoint.current.y),
+        'y',
+        scaleRef.current
+      );
+
+      translateRef.current = { x: nextX, y: nextY };
+      imageTranslateX.setValue(nextX);
+      imageTranslateY.setValue(nextY);
+    }
+  };
+
+  const handleTouchEnd = (event: GestureResponderEvent) => {
+    const touches = event.nativeEvent.touches;
+
+    if (touches.length >= 2) {
+      gestureStartScale.current = scaleRef.current;
+      gestureStartTranslate.current = { ...translateRef.current };
+      pinchStartDistance.current = getTouchDistance(touches);
+      activeGesture.current = 'pinch';
+      return;
+    }
+
+    if (touches.length === 1 && scaleRef.current > 1.01) {
+      activeGesture.current = 'pan';
+      gestureStartTranslate.current = { ...translateRef.current };
+      panStartPoint.current = {
+        x: touches[0].pageX,
+        y: touches[0].pageY,
+      };
+      return;
+    }
+
+    finishGesture();
+  };
 
   useEffect(() => {
     if (visible) {
       setCurrentIndex(initialIndex);
+      resetZoom();
     }
   }, [visible, initialIndex]);
+
+  useEffect(() => {
+    resetZoom();
+  }, [currentIndex]);
 
   useEffect(() => {
     if (visible && Platform.OS === 'web') {
@@ -107,12 +312,32 @@ export default function ImageLightbox({
         ]}
       >
         {imageUri ? (
-          <Image
-            source={{ uri: imageUri }}
-            style={styles.image}
-            resizeMode="contain"
-            accessibilityLabel={`Image ${currentIndex + 1} of ${images.length}`}
-          />
+          <Animated.View
+            onStartShouldSetResponder={() => Platform.OS !== 'web'}
+            onMoveShouldSetResponder={() => Platform.OS !== 'web'}
+            onResponderTerminationRequest={() => false}
+            onResponderGrant={handleTouchStart}
+            onResponderMove={handleTouchMove}
+            onResponderRelease={handleTouchEnd}
+            onResponderTerminate={finishGesture}
+            style={styles.zoomSurface}
+          >
+            <Animated.Image
+              source={{ uri: imageUri }}
+              style={[
+                styles.image,
+                {
+                  transform: [
+                    { scale: imageScale },
+                    { translateX: imageTranslateX },
+                    { translateY: imageTranslateY },
+                  ],
+                },
+              ]}
+              resizeMode="contain"
+              accessibilityLabel={`Image ${currentIndex + 1} of ${images.length}`}
+            />
+          </Animated.View>
         ) : (
           <View style={styles.placeholder}>
             <Text style={styles.placeholderText}>Image unavailable</Text>
@@ -120,7 +345,7 @@ export default function ImageLightbox({
         )}
       </View>
 
-      {hasMultiple && (
+      {hasMultiple && !isZoomed && (
         <>
           <Pressable
             style={({ pressed }) => [
@@ -153,7 +378,15 @@ export default function ImageLightbox({
         </>
       )}
 
-      {hasMultiple && (
+      {Platform.OS !== 'web' && (
+        <View style={[styles.zoomHint, { top: Math.max(insets.top + 64, 76) }]}>
+          <Text style={styles.zoomHintText}>
+            {isZoomed ? 'Drag to inspect details' : 'Pinch to zoom'}
+          </Text>
+        </View>
+      )}
+
+      {hasMultiple && !isZoomed && (
         <View style={[styles.indicators, { bottom: Math.max(insets.bottom + 16, 24) }]}>
           <Text style={styles.counterText}>
             {currentIndex + 1} / {images.length}
@@ -226,6 +459,11 @@ const styles = StyleSheet.create({
     height: '85%',
     zIndex: 5,
   },
+  zoomSurface: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   image: {
     width: '100%',
     height: '100%',
@@ -274,6 +512,20 @@ const styles = StyleSheet.create({
     zIndex: 10,
     alignItems: 'center',
     gap: spacing.sm,
+  },
+  zoomHint: {
+    position: 'absolute',
+    zIndex: 10,
+    alignSelf: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: 999,
+    backgroundColor: 'rgba(15, 23, 42, 0.6)',
+  },
+  zoomHintText: {
+    ...typography.footnote,
+    color: 'rgba(255, 255, 255, 0.9)',
+    fontWeight: '600',
   },
   counterText: {
     ...typography.footnote,


### PR DESCRIPTION
## Linked Issues

Closes #<issue-number>
Linear: POLY-82

## Summary

Adds zoom support to listing photos in the shared image lightbox so buyers can inspect item details more closely.

The previous lightbox supported opening photos and moving between images, but it did not support zooming. This change adds pinch-to-zoom and panning inside the lightbox on native, resets zoom when switching images, and hides image navigation controls while zoomed so they do not interfere with inspection.

## How to Test

Steps to verify locally:

- `npm run lint`
- `npm run typecheck`
- `npm test`

- Manual flow:
  1. `npm run dev:backend` (in terminal A)
  2. `npm run dev` (in terminal B)
  3. Open a listing with one or more photos
  4. Tap a listing photo to open the lightbox
  5. On Android emulator, hold `Ctrl` and drag to simulate pinch zoom
  6. Verify the image zooms in and out
  7. Verify that once zoomed in, the image can be dragged to inspect details
  8. Verify that previous/next arrows and dot indicators are hidden while zoomed and reappear when zoom returns to normal
  9. Verify that changing images resets the zoom state

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Lint/tests pass locally (`npm run lint`)
- [ ] Docs updated (README/ADR/changelog if needed)
- [x] Follows conventional commit format
- [x] No merge conflicts with `dev`

## Screenshots / Demos

Attach a short screen recording or screenshots showing:
- a listing photo opened in the lightbox
- pinch-to-zoom working
- panning while zoomed
- controls hidden during zoom and restored afterward
- 

Uploading TicTacToe – TicTacToeBoard.java [TicTacToe.app.main] 2026-04-18 17-02-06.mp4…

<img width="624" height="777" alt="Screenshot 2026-04-18 170414" src="https://github.com/user-attachments/assets/84aed66c-44eb-462d-bde5-89607a89178b" />
<img width="287" height="634" alt="image" src="https://github.com/user-attachments/assets/8fedfcf9-aefc-479d-88d4-e16bcf6346e2" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pinch-to-zoom gesture support (1x–4x zoom range) for images in the lightbox on mobile platforms.
  * Added pan/drag functionality to move around zoomed images.
  * Navigation controls automatically hide when an image is zoomed.
  * Added interactive hint to guide users on zoom and drag gestures on mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->