### PR TITLE
POLY-84-Fixed-Choppy-Exit-Search

### DIFF
--- a/frontend/app/(tabs)/search/index.tsx
+++ b/frontend/app/(tabs)/search/index.tsx
@@ -73,8 +73,9 @@ export default function SearchScreen() {
   );
 
   const clearSearchAndBrowse = useCallback(() => {
-    setCategoryFilter(null);
     setSearchInput('');
+    setSearchTerm('');
+    setCategoryFilter(null);
   }, []);
 
   useEffect(() => {
@@ -162,7 +163,7 @@ export default function SearchScreen() {
     [router]
   );
 
-  const hasActiveQuery = searchTerm.length > 0 || categoryFilter !== null;
+  const hasActiveQuery = searchInput.trim().length > 0 || categoryFilter !== null;
   const isSearching = hasActiveQuery;
   const isInitialLoading =
     isSearching && listingsResult === undefined && cursor === null && allListings.length === 0;
@@ -397,7 +398,7 @@ export default function SearchScreen() {
               />
               {searchInput.length > 0 ? (
                 <Pressable
-                  onPress={() => setSearchInput('')}
+                  onPress={clearSearchAndBrowse}
                   style={[
                     styles.searchClearButton,
                     { backgroundColor: searchChrome.clearButtonBackground },


### PR DESCRIPTION
## Linked Issues

Closes #84
Linear: POLY-84 (e.g., POLY-123)

## Summary

I figured the reason for the choppy animation when pressing X on search is because we clear the searchInput immediately; however, searchTerm has a delay, so I set it so it clears that as well on press. (also clears category filter immediately)

## How to Test

Steps to verify locally:

- `npm run lint`
- `npm run typecheck`
- `npm test`
- Manual flow:
  1. `npm run dev:backend` (in terminal A)
  2. `npm run dev` (in terminal B)
  3. Verify the change: <describe expected behavior/screens>

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Lint/tests pass locally (`npm run lint`)
- [ ] Docs updated (README/ADR/changelog if needed)
- [ ] Follows conventional commit format
- [ ] No merge conflicts with `dev`

## Screenshots / Demos

(if UI or visible behavior - attach images, videos, or GIFs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search clearing behavior—the clear button now properly clears both search input and category filters together.
  * Enhanced search responsiveness—the UI now immediately reflects changes to search input rather than waiting for processing delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->