### PR TITLE
Remove ability to login on web

### DIFF
--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -195,11 +195,18 @@ export default function HomeScreen() {
 
   const savedState = useQuery(
     api.savedListings.getSavedStateForListings,
-    isAuthenticated && listings.length > 0 ? { listingIds: listings.map((l) => l._id) } : 'skip'
+    isAuthenticated && !isWeb && listings.length > 0
+      ? { listingIds: listings.map((l) => l._id) }
+      : 'skip'
   );
 
   const handleToggleSave = useCallback(
     async (listingId: Id<'listings'>) => {
+      if (isWeb) {
+        router.push('/auth/login?returnTo=%2F' as never);
+        return;
+      }
+
       if (!isAuthenticated) {
         router.replace('/auth/login?returnTo=%2F' as never);
         return;
@@ -213,7 +220,7 @@ export default function HomeScreen() {
         Alert.alert('Save failed', message);
       }
     },
-    [isAuthenticated, router, toggleSavedListing]
+    [isAuthenticated, isWeb, router, toggleSavedListing]
   );
 
   const hasActiveFilters =
@@ -254,15 +261,19 @@ export default function HomeScreen() {
   }, [refreshListings]);
 
   const handleCreateListing = () => {
+    if (isWeb) {
+      router.push({
+        pathname: '/auth/login',
+        params: { returnTo: '/listings/new' },
+      } as never);
+      return;
+    }
+
     if (!isAuthenticated) {
-      if (Platform.OS === 'web') {
-        router.replace('/settings');
-      } else {
-        Alert.alert('Sign In Required', 'Please sign in to create a listing', [
-          { text: 'Cancel', style: 'cancel' },
-          { text: 'Sign In', onPress: () => router.replace('/auth/login') },
-        ]);
-      }
+      Alert.alert('Sign In Required', 'Please sign in to create a listing', [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Sign In', onPress: () => router.replace('/auth/login') },
+      ]);
       return;
     }
     router.push('/listings/new');
@@ -394,11 +405,17 @@ export default function HomeScreen() {
               ]}
               onPress={handleCreateListing}
               disabled={isSessionLoading}
-              accessibilityLabel="Create listing"
+              accessibilityLabel={
+                isWeb ? 'Download the Mobile App to Create Listings' : 'Create listing'
+              }
               accessibilityRole="button"
             >
-              <Text style={styles.createChipText}>
-                {isAuthenticated ? '+ Create listing' : 'Sign in to sell'}
+              <Text style={[styles.createChipText, isWeb && styles.webCreateChipText]}>
+                {isWeb
+                  ? 'Download the Mobile App to Create Listings'
+                  : isAuthenticated
+                    ? '+ Create listing'
+                    : 'Sign in to sell'}
               </Text>
             </Pressable>
           </Animated.View>
@@ -438,7 +455,6 @@ export default function HomeScreen() {
                           listing={item}
                           index={row.startIndex + columnOffset}
                           isSaved={savedState?.[item._id] ?? false}
-                          onToggleSave={() => void handleToggleSave(item._id as Id<'listings'>)}
                           density="home"
                           shellStyle="flat"
                         />
@@ -654,8 +670,11 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   webCreateChip: {
-    minWidth: 172,
+    minWidth: 280,
     alignItems: 'center',
+  },
+  webCreateChipText: {
+    textAlign: 'center',
   },
   homeTopBlock: {
     gap: spacing.md,

--- a/frontend/app/(tabs)/search/index.tsx
+++ b/frontend/app/(tabs)/search/index.tsx
@@ -135,20 +135,25 @@ export default function SearchScreen() {
 
   const savedState = useQuery(
     api.savedListings.getSavedStateForListings,
-    isAuthenticated && allListings.length > 0
+    isAuthenticated && !isWeb && allListings.length > 0
       ? { listingIds: allListings.map((l) => l._id) }
       : 'skip'
   );
 
   const handleToggleSave = useCallback(
     (listingId: Id<'listings'>) => {
+      if (isWeb) {
+        router.push('/auth/login?returnTo=%2Fsearch' as never);
+        return;
+      }
+
       if (!isAuthenticated) {
         router.replace('/auth/login?returnTo=%2Fsearch' as never);
         return;
       }
       void toggleSavedListing({ listingId });
     },
-    [isAuthenticated, router, toggleSavedListing]
+    [isAuthenticated, isWeb, router, toggleSavedListing]
   );
 
   const handleCategoryPress = useCallback((category: Category) => {
@@ -258,7 +263,7 @@ export default function SearchScreen() {
           listing={item}
           index={index}
           isSaved={savedState?.[item._id] ?? false}
-          onToggleSave={() => handleToggleSave(item._id)}
+          onToggleSave={isWeb ? undefined : () => handleToggleSave(item._id)}
           onPress={() => handleListingPress(item)}
         />
       )}

--- a/frontend/app/auth/login.tsx
+++ b/frontend/app/auth/login.tsx
@@ -21,6 +21,7 @@ import { useEntranceAnimation } from '../../hooks/useEntranceAnimation';
 import { useAuth } from '../../hooks/useAuth';
 import { requestPermissionAndSyncToken } from '../../hooks/usePushNotifications';
 import { getLoginEntryAction, type LoginStep } from './loginRedirect';
+import OpenInAppPrompt from '../../components/OpenInAppPrompt';
 import { colors, typography, spacing, borderRadius } from '../../theme/tokens';
 
 const APP_REVIEW_EMAIL = (process.env.EXPO_PUBLIC_APP_REVIEW_EMAIL ?? '').toLowerCase().trim();
@@ -34,6 +35,7 @@ function providerForEmail(emailAddress: string): 'resend-otp' | 'ios-review-otp'
 
 export default function LoginScreen() {
   const router = useRouter();
+  const isWeb = Platform.OS === 'web';
   const { returnTo } = useLocalSearchParams<{ returnTo?: string | string[] }>();
   const { signIn } = useAuthActions();
   const { isAuthenticated, isSessionLoading } = useAuth();
@@ -44,7 +46,10 @@ export default function LoginScreen() {
     api.users.updateMessageNotificationsEnabled
   );
 
-  const currentProfile = useQuery(api.profiles.getCurrentProfile, isAuthenticated ? {} : 'skip');
+  const currentProfile = useQuery(
+    api.profiles.getCurrentProfile,
+    isAuthenticated && !isWeb ? {} : 'skip'
+  );
 
   const [step, setStep] = useState<LoginStep>('welcome');
   const [email, setEmail] = useState('');
@@ -295,6 +300,19 @@ export default function LoginScreen() {
   const isPushStep = step === 'push';
   const isSuccessStep = step === 'success';
   const verificationEmail = typeof step === 'object' && 'email' in step ? step.email : '';
+
+  if (isWeb) {
+    return (
+      <OpenInAppPrompt
+        title="Sign in on mobile"
+        body="Login is only available in the PolyBuys mobile app."
+        path={String(postAuthRedirect)}
+        buttonLabel="Open PolyBuys App"
+        secondaryActionLabel="Back to home"
+        onSecondaryAction={() => router.replace('/')}
+      />
+    );
+  }
 
   if (isWelcomeStep) {
     return (

--- a/frontend/app/conversations/[id].tsx
+++ b/frontend/app/conversations/[id].tsx
@@ -18,6 +18,7 @@ import { api } from 'convex/_generated/api';
 import { Id } from 'convex/_generated/dataModel';
 import { useAuth } from '../../hooks/useAuth';
 import { useResolvedImageUrls } from '../../hooks/useResolvedImageUrls';
+import OpenInAppPrompt from '../../components/OpenInAppPrompt';
 import ProfileAvatar from '../../components/ProfileAvatar';
 import SafetyBanner from '../../components/SafetyBanner';
 import { ScreenState } from '../../components/ScreenState';
@@ -38,6 +39,7 @@ export default function ConversationDetailScreen() {
     typeof id === 'string' && id.trim().length > 0 ? (id as ConversationId) : null;
 
   const router = useRouter();
+  const isWeb = Platform.OS === 'web';
   const insets = useSafeAreaInsets();
   const headerHeight = useHeaderHeight();
   const { user, isAuthenticated, isSessionLoading } = useAuth();
@@ -54,11 +56,11 @@ export default function ConversationDetailScreen() {
 
   const currentUserSubject = useQuery(
     api.listings.getCurrentUserSubject,
-    isAuthenticated ? {} : 'skip'
+    isAuthenticated && !isWeb ? {} : 'skip'
   );
   const conversationList = useQuery(
     api.messages.listUserConversations,
-    isAuthenticated ? {} : 'skip'
+    isAuthenticated && !isWeb ? {} : 'skip'
   );
 
   const conversation = useMemo(() => {
@@ -84,21 +86,25 @@ export default function ConversationDetailScreen() {
   const otherUserId = conversation?.canonicalOtherUserId ?? null;
   const isBlockingOther = useQuery(
     api.blocks.isBlocking,
-    isAuthenticated && otherUserId ? { blockedId: otherUserId } : 'skip'
+    isAuthenticated && !isWeb && otherUserId ? { blockedId: otherUserId } : 'skip'
   );
   const isBlockedByOther = useQuery(
     api.blocks.isBlockedBy,
-    isAuthenticated && otherUserId ? { blockerId: otherUserId } : 'skip'
+    isAuthenticated && !isWeb && otherUserId ? { blockerId: otherUserId } : 'skip'
   );
   const isBlockStatusLoading =
     isAuthenticated &&
+    !isWeb &&
     otherUserId !== null &&
     (isBlockingOther === undefined || isBlockedByOther === undefined);
 
   const listingId = (conversation?.listing?.id ??
     conversation?.listingId ??
     null) as Id<'listings'> | null;
-  const listing = useQuery(api.listings.getListing, listingId ? { id: listingId } : 'skip');
+  const listing = useQuery(
+    api.listings.getListing,
+    !isWeb && listingId ? { id: listingId } : 'skip'
+  );
   const headerOtherUserPicture = conversation?.otherUser?.picture ?? null;
   const { mappedUrls: headerAvatarMappedUrls } = useResolvedImageUrls(
     headerOtherUserPicture ? [headerOtherUserPicture] : []
@@ -111,7 +117,7 @@ export default function ConversationDetailScreen() {
 
   const messages = useQuery(
     api.messages.messagesByConversation,
-    isAuthenticated && conversationId && conversation
+    isAuthenticated && !isWeb && conversationId && conversation
       ? {
           conversationId,
           siblingConversationIds:
@@ -135,11 +141,11 @@ export default function ConversationDetailScreen() {
   };
 
   useEffect(() => {
-    if (!isSessionLoading && !isAuthenticated) {
+    if (!isWeb && !isSessionLoading && !isAuthenticated) {
       const returnTo = conversationId ? `/conversations/${conversationId}` : '/inbox';
       router.replace(`/auth/login?returnTo=${encodeURIComponent(returnTo)}` as never);
     }
-  }, [isSessionLoading, conversationId, isAuthenticated, router]);
+  }, [isSessionLoading, conversationId, isAuthenticated, isWeb, router]);
 
   useEffect(() => {
     if (!messages) {
@@ -159,6 +165,7 @@ export default function ConversationDetailScreen() {
     if (
       !conversationId ||
       !isAuthenticated ||
+      isWeb ||
       unreadIncomingCount === 0 ||
       !siblingConversationIds
     ) {
@@ -184,6 +191,7 @@ export default function ConversationDetailScreen() {
   }, [
     conversationId,
     isAuthenticated,
+    isWeb,
     markMessagesAsRead,
     siblingConversationIds,
     unreadIncomingCount,
@@ -254,6 +262,19 @@ export default function ConversationDetailScreen() {
       <View style={styles.centeredState}>
         <Text style={styles.stateTitle}>Conversation not found</Text>
       </View>
+    );
+  }
+
+  if (isWeb) {
+    return (
+      <OpenInAppPrompt
+        title="Open this conversation in the mobile app"
+        body="Messaging is only available in the PolyBuys mobile app."
+        path={`/conversations/${conversationId}`}
+        buttonLabel="Open Conversation in App"
+        secondaryActionLabel="Back to home"
+        onSecondaryAction={() => router.replace('/')}
+      />
     );
   }
 

--- a/frontend/app/conversations/new.tsx
+++ b/frontend/app/conversations/new.tsx
@@ -16,6 +16,7 @@ import { api } from 'convex/_generated/api';
 import { Id } from 'convex/_generated/dataModel';
 import { useAuth } from '../../hooks/useAuth';
 import { useResolvedImageUrls } from '../../hooks/useResolvedImageUrls';
+import OpenInAppPrompt from '../../components/OpenInAppPrompt';
 import ProfileAvatar from '../../components/ProfileAvatar';
 import { ScreenState } from '../../components/ScreenState';
 import { colors, typography, spacing, borderRadius } from '../../theme/tokens';
@@ -29,15 +30,19 @@ export default function NewConversationScreen() {
 
   const router = useRouter();
   const headerHeight = useHeaderHeight();
+  const isWeb = Platform.OS === 'web';
   const { isAuthenticated, isSessionLoading } = useAuth();
   const createConversationAndSendFirstMessage = useAction(
     api.messages.createConversationAndSendFirstMessage
   );
 
-  const listing = useQuery(api.listings.getListing, listingId ? { id: listingId } : 'skip');
+  const listing = useQuery(
+    api.listings.getListing,
+    !isWeb && listingId ? { id: listingId } : 'skip'
+  );
   const sellerProfile = useQuery(
     api.profiles.getProfileByUserId,
-    listing?.sellerId ? { userId: listing.sellerId } : 'skip'
+    !isWeb && listing?.sellerId ? { userId: listing.sellerId } : 'skip'
   );
   const { mappedUrls: sellerAvatarUrls } = useResolvedImageUrls(
     sellerProfile?.picture ? [sellerProfile.picture] : []
@@ -70,11 +75,26 @@ export default function NewConversationScreen() {
   };
 
   useEffect(() => {
-    if (!isSessionLoading && !isAuthenticated) {
+    if (!isWeb && !isSessionLoading && !isAuthenticated) {
       const returnTo = listingId ? `/conversations/new?listingId=${listingId}` : '/inbox';
       router.replace(`/auth/login?returnTo=${encodeURIComponent(returnTo)}` as Href);
     }
-  }, [isSessionLoading, isAuthenticated, listingId, router]);
+  }, [isSessionLoading, isAuthenticated, isWeb, listingId, router]);
+
+  if (isWeb) {
+    return (
+      <OpenInAppPrompt
+        title="Start conversations in the mobile app"
+        body="Messaging is available in the PolyBuys mobile app."
+        path={listingId ? `/conversations/new?listingId=${listingId}` : '/inbox'}
+        buttonLabel="Open Messaging in App"
+        secondaryActionLabel="Back to listing"
+        onSecondaryAction={() =>
+          listingId ? router.replace(`/listings/${listingId}` as never) : router.replace('/')
+        }
+      />
+    );
+  }
 
   if (!listingId) {
     return (

--- a/frontend/app/listings/[id].tsx
+++ b/frontend/app/listings/[id].tsx
@@ -74,6 +74,7 @@ export default function ListingDetailScreen() {
   const router = useRouter();
   const { setFlash } = useFlash();
   const { isAuthenticated } = useAuth();
+  const isWeb = Platform.OS === 'web';
   const entranceStyle = useEntranceAnimation();
   const appOrigin = getAppOrigin();
 
@@ -83,14 +84,14 @@ export default function ListingDetailScreen() {
   );
   const currentUserSubject = useQuery(
     api.listings.getCurrentUserSubject,
-    isAuthenticated ? {} : 'skip'
+    isAuthenticated && !isWeb ? {} : 'skip'
   );
   const toggleSavedListing = useMutation(api.savedListings.toggleSavedListing);
   const updateListingStatus = useMutation(api.listings.updateListingStatus);
   const [markingSold, setMarkingSold] = useState(false);
   const isSaved = useQuery(
     api.savedListings.isListingSaved,
-    listingId && isAuthenticated ? { listingId: listingId as Id<'listings'> } : 'skip'
+    listingId && isAuthenticated && !isWeb ? { listingId: listingId as Id<'listings'> } : 'skip'
   );
   const [reportOpen, setReportOpen] = useState(false);
   const [savedOptimistic, setSavedOptimistic] = useState<boolean | null>(null);
@@ -127,6 +128,14 @@ export default function ListingDetailScreen() {
   const onMessageSellerPress = () => {
     if (!listing) return;
 
+    if (isWeb) {
+      router.push({
+        pathname: '/auth/login',
+        params: { returnTo: `/listings/${listing._id}` },
+      } as never);
+      return;
+    }
+
     if (!isAuthenticated) {
       const redirectTo = `/listings/${listing._id}`;
       router.replace(`/auth/login?returnTo=${encodeURIComponent(redirectTo)}` as never);
@@ -141,6 +150,14 @@ export default function ListingDetailScreen() {
 
   const onSavePress = async () => {
     if (!listingId) return;
+
+    if (isWeb) {
+      router.push({
+        pathname: '/auth/login',
+        params: { returnTo: `/listings/${listingId}` },
+      } as never);
+      return;
+    }
 
     if (!isAuthenticated) {
       router.replace(
@@ -233,7 +250,7 @@ export default function ListingDetailScreen() {
     return <ListingUnavailable />;
   }
 
-  if (listing === undefined || (isAuthenticated && currentUserSubject === undefined)) {
+  if (listing === undefined || (!isWeb && isAuthenticated && currentUserSubject === undefined)) {
     return (
       <View style={styles.loadingContainer}>
         <ScreenState variant="loading" title="Loading listing..." />
@@ -546,7 +563,7 @@ export default function ListingDetailScreen() {
           </View>
         )}
 
-        {!isOwner && (
+        {!isOwner && !isWeb && (
           <Pressable
             style={({ pressed }) => [styles.reportLink, pressed && styles.buttonPressed]}
             onPress={() => setReportOpen(true)}

--- a/frontend/app/listings/[id]/edit.tsx
+++ b/frontend/app/listings/[id]/edit.tsx
@@ -16,6 +16,7 @@ import { api } from 'convex/_generated/api';
 import type { Id } from 'convex/_generated/dataModel';
 import ImageUploader from '@/components/ImageUploader';
 import ListingUnavailable from '../../../components/ListingUnavailable';
+import OpenInAppPrompt from '../../../components/OpenInAppPrompt';
 import { useFlash } from '../../../contexts/FlashContext';
 import { useEntranceAnimation } from '../../../hooks/useEntranceAnimation';
 import { KeyboardAwareScreen, ScreenHeader } from '../../../components/ui';
@@ -52,12 +53,13 @@ function getListingActionError(error: unknown, fallbackTitle: string) {
 
 export default function EditListingScreen() {
   const router = useRouter();
+  const isWeb = Platform.OS === 'web';
   const { setFlash } = useFlash();
   const { id } = useLocalSearchParams<{ id?: string | string[] }>();
   const listingId = typeof id === 'string' && id.trim().length > 0 ? id : null;
   const listing = useQuery(
     api.listings.getListing,
-    listingId ? { id: listingId as Id<'listings'> } : 'skip'
+    !isWeb && listingId ? { id: listingId as Id<'listings'> } : 'skip'
   );
   const updateListing = useAction(api.listings.updateListing);
   const entranceStyle = useEntranceAnimation();
@@ -86,6 +88,19 @@ export default function EditListingScreen() {
     setImages(listing.images);
     setHasInitialized(true);
   }, [hasInitialized, listing]);
+
+  if (isWeb) {
+    return (
+      <OpenInAppPrompt
+        title="Edit listings in the mobile app"
+        body="Listing management is available in the PolyBuys mobile app."
+        path={listingId ? `/listings/${listingId}/edit` : '/my-listings'}
+        buttonLabel="Open Listing Editor in App"
+        secondaryActionLabel="Back to listing"
+        onSecondaryAction={() => router.replace(listingId ? `/listings/${listingId}` : '/')}
+      />
+    );
+  }
 
   async function onSubmit() {
     if (submittingRef.current || !listingId) {

--- a/frontend/app/listings/new.tsx
+++ b/frontend/app/listings/new.tsx
@@ -17,6 +17,7 @@ import ImageUploader from '@/components/ImageUploader';
 import { useFlash } from '../../contexts/FlashContext';
 import { useAuth } from '../../hooks/useAuth';
 import { useEntranceAnimation } from '../../hooks/useEntranceAnimation';
+import OpenInAppPrompt from '../../components/OpenInAppPrompt';
 import { KeyboardAwareScreen, ScreenHeader } from '../../components/ui';
 import { colors, typography, borderRadius, spacing } from '../../theme/tokens';
 
@@ -60,11 +61,12 @@ function getListingActionError(error: unknown, fallbackTitle: string) {
 
 export default function NewListingScreen() {
   const router = useRouter();
+  const isWeb = Platform.OS === 'web';
   const { setFlash } = useFlash();
   const createListing = useAction(api.listings.createListing);
   const { isAuthenticated, isSessionLoading } = useAuth();
   const entranceStyle = useEntranceAnimation();
-  const profile = useQuery(api.profiles.getCurrentProfile, isAuthenticated ? {} : 'skip');
+  const profile = useQuery(api.profiles.getCurrentProfile, isAuthenticated && !isWeb ? {} : 'skip');
 
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
@@ -77,11 +79,24 @@ export default function NewListingScreen() {
   const submittingRef = useRef(false);
 
   useEffect(() => {
-    if (!isSessionLoading && !isAuthenticated) {
+    if (!isWeb && !isSessionLoading && !isAuthenticated) {
       showAlert('Sign In Required', 'Please sign in to create a listing');
       router.replace('/auth/login');
     }
-  }, [isAuthenticated, isSessionLoading, router]);
+  }, [isAuthenticated, isSessionLoading, isWeb, router]);
+
+  if (isWeb) {
+    return (
+      <OpenInAppPrompt
+        title="Create listings in the mobile app"
+        body="Posting items is available in the PolyBuys mobile app."
+        path="/listings/new"
+        buttonLabel="Open Create Listing in App"
+        secondaryActionLabel="Back to home"
+        onSecondaryAction={() => router.replace('/')}
+      />
+    );
+  }
 
   async function onSubmit() {
     if (submittingRef.current) {

--- a/frontend/app/profile/[userId].tsx
+++ b/frontend/app/profile/[userId].tsx
@@ -1,4 +1,12 @@
-import { Pressable, ScrollView, StyleSheet, Text, View, useWindowDimensions } from 'react-native';
+import {
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  useWindowDimensions,
+} from 'react-native';
 import { useState } from 'react';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useQuery } from 'convex/react';
@@ -27,6 +35,7 @@ export default function PublicProfileScreen() {
   const router = useRouter();
   const { setFlash } = useFlash();
   const { width } = useWindowDimensions();
+  const isWeb = Platform.OS === 'web';
   const { user, isAuthenticated } = useAuth();
   const [reportOpen, setReportOpen] = useState(false);
   let resolvedUserId: string | null = null;
@@ -55,7 +64,7 @@ export default function PublicProfileScreen() {
   const avatarUrl = avatarUrls[0];
   const isWideLayout = width >= 980;
   const canReportProfile =
-    isAuthenticated && resolvedUserId !== null && user?._id !== resolvedUserId;
+    !isWeb && isAuthenticated && resolvedUserId !== null && user?._id !== resolvedUserId;
 
   if (!resolvedUserId) {
     return (

--- a/frontend/app/profile/edit.tsx
+++ b/frontend/app/profile/edit.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
+  Platform,
   Pressable,
   StyleSheet,
   Text,
@@ -16,6 +17,7 @@ import * as ImagePicker from 'expo-image-picker';
 import { SaveFormat, manipulateAsync } from 'expo-image-manipulator';
 import { getEmailValidationError } from '@polybuys/shared';
 import { useAuth } from '../../hooks/useAuth';
+import OpenInAppPrompt from '../../components/OpenInAppPrompt';
 import ProfileAvatar from '../../components/ProfileAvatar';
 import { KeyboardAwareScreen } from '../../components/ui';
 import { useResolvedImageUrls } from '../../hooks/useResolvedImageUrls';
@@ -112,9 +114,10 @@ async function uploadImageToConvex(
 
 export default function ProfileEditScreen() {
   const router = useRouter();
+  const isWeb = Platform.OS === 'web';
   const { isAuthenticated } = useAuth();
   const { setFlash } = useFlash();
-  const profile = useQuery(api.profiles.getCurrentProfile, isAuthenticated ? {} : 'skip');
+  const profile = useQuery(api.profiles.getCurrentProfile, isAuthenticated && !isWeb ? {} : 'skip');
   const createProfile = useMutation(api.profiles.createProfile);
   const updateProfile = useMutation(api.profiles.updateProfile);
   const generateUploadUrl = useMutation(api.profiles.generateUploadUrl);
@@ -159,10 +162,10 @@ export default function ProfileEditScreen() {
   }, [isAuthenticated, profile, loadedKey]);
 
   useEffect(() => {
-    if (!isAuthenticated) {
+    if (!isWeb && !isAuthenticated) {
       router.replace('/auth/login?returnTo=%2Fprofile%2Fedit' as never);
     }
-  }, [isAuthenticated, router]);
+  }, [isAuthenticated, isWeb, router]);
 
   useEffect(() => {
     return () => {
@@ -312,6 +315,19 @@ export default function ProfileEditScreen() {
       setIsSubmitting(false);
     }
   };
+
+  if (isWeb) {
+    return (
+      <OpenInAppPrompt
+        title="Edit your profile in the mobile app"
+        body="Profile editing is available in the PolyBuys mobile app."
+        path="/profile/edit"
+        buttonLabel="Open Profile Editor in App"
+        secondaryActionLabel="Back to home"
+        onSecondaryAction={() => router.replace('/')}
+      />
+    );
+  }
 
   if (!isAuthenticated || profile === undefined) {
     return (


### PR DESCRIPTION
## Linked Issues

Closes #POLY-80
Linear: POLY-80

## Summary

- Removed web login flow UI: `/auth/login` on web now shows the **Sign in on mobile** prompt.
- Updated web gating so login-required actions route to that same prompt (not the welcome/get-started step), including:
  - **Message Seller** from listing detail
  - Home web CTA (**Download the Mobile App to Create and Engage with Listings**)
- Restricted additional auth-required web actions (save/message/manage/edit/profile flows) to app-only behavior.

## How to Test

Steps to verify locally:

- `npm run lint`
- `npm run typecheck`
- `npm test`
- Manual flow:
  1. `npm run dev:backend` (in terminal A)
  2. `npm run dev` (in terminal B)
  3. Verify the change: <describe expected behavior/screens>

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Lint/tests pass locally (`npm run lint`)
- [ ] Docs updated (README/ADR/changelog if needed)
- [ ] Follows conventional commit format
- [ ] No merge conflicts with `dev`

## Screenshots / Demos

(if UI or visible behavior - attach images, videos, or GIFs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-app prompts directing web users to download the mobile app for key features.

* **Changes**
  * Restricted listing creation, editing, saving, messaging, profile editing, and reporting to mobile platforms.
  * Web users attempting these actions are prompted to access the mobile app instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->