### PR TITLE
feat: add support page and links across the application

### DIFF
--- a/frontend/app/support.tsx
+++ b/frontend/app/support.tsx
@@ -1,0 +1,5 @@
+import { Redirect, type Href } from 'expo-router';
+
+export default function SupportRoute() {
+  return <Redirect href={'/home' as Href} />;
+}

--- a/frontend/app/support.web.tsx
+++ b/frontend/app/support.web.tsx
@@ -1,0 +1,12 @@
+import { LegalDocumentPage } from '../components/landing/LegalDocument.web';
+import { getSupportDocument } from '../components/landing/legalContent';
+
+export default function SupportRoute() {
+  return (
+    <LegalDocumentPage
+      legalDocument={getSupportDocument()}
+      siblingHref="/privacy"
+      siblingLabel="Privacy Policy"
+    />
+  );
+}

--- a/frontend/components/LandingScreen.tsx
+++ b/frontend/components/LandingScreen.tsx
@@ -1,5 +1,5 @@
 import Head from 'expo-router/head';
-import { Link, useRouter } from 'expo-router';
+import { Link, useRouter, type Href } from 'expo-router';
 import {
   Image,
   Linking,
@@ -24,6 +24,11 @@ const APP_STORE_BADGE_URI =
   'https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83';
 
 const LAYOUT_BREAKPOINT = 768;
+
+const HOME_HREF = '/home' as Href;
+const SUPPORT_PAGE_HREF = '/support' as Href;
+const PRIVACY_PAGE_HREF = '/privacy' as Href;
+const TERMS_PAGE_HREF = '/terms' as Href;
 
 function openDownloadLinkEmail() {
   const subject = encodeURIComponent('PolyBuys — download link');
@@ -66,7 +71,7 @@ export default function LandingScreen() {
       ) : null}
       <SafeAreaView style={styles.safe} edges={['top', 'bottom']}>
         <View style={styles.topBar}>
-          <Link href="/home" asChild>
+          <Link href={HOME_HREF} asChild>
             <Pressable
               accessibilityRole="link"
               accessibilityLabel="Go to marketplace"
@@ -94,7 +99,7 @@ export default function LandingScreen() {
             <View style={styles.ctaRow}>
               <AppButton
                 size="lg"
-                onPress={() => router.push('/home')}
+                onPress={() => router.push(HOME_HREF)}
                 accessibilityLabel="Browse marketplace"
               >
                 Browse marketplace
@@ -187,6 +192,50 @@ export default function LandingScreen() {
               </View>
             )}
           </SectionCard>
+
+          {Platform.OS === 'web' ? (
+            <View style={styles.legalLinksRow}>
+              <Link href={SUPPORT_PAGE_HREF} asChild>
+                <Pressable
+                  accessibilityRole="link"
+                  accessibilityLabel="Support"
+                  style={({ pressed }) => [pressed && styles.pressed]}
+                >
+                  <AppText variant="footnoteMed" color="primary">
+                    Support
+                  </AppText>
+                </Pressable>
+              </Link>
+              <AppText variant="footnote" color="muted" style={styles.legalLinksSep}>
+                ·
+              </AppText>
+              <Link href={PRIVACY_PAGE_HREF} asChild>
+                <Pressable
+                  accessibilityRole="link"
+                  accessibilityLabel="Privacy Policy"
+                  style={({ pressed }) => [pressed && styles.pressed]}
+                >
+                  <AppText variant="footnoteMed" color="primary">
+                    Privacy
+                  </AppText>
+                </Pressable>
+              </Link>
+              <AppText variant="footnote" color="muted" style={styles.legalLinksSep}>
+                ·
+              </AppText>
+              <Link href={TERMS_PAGE_HREF} asChild>
+                <Pressable
+                  accessibilityRole="link"
+                  accessibilityLabel="Terms of Service"
+                  style={({ pressed }) => [pressed && styles.pressed]}
+                >
+                  <AppText variant="footnoteMed" color="primary">
+                    Terms
+                  </AppText>
+                </Pressable>
+              </Link>
+            </View>
+          ) : null}
 
           <AppText variant="footnote" color="muted" style={styles.footerNote}>
             PolyBuys is an independent student marketplace and is not affiliated with California
@@ -303,6 +352,17 @@ const styles = StyleSheet.create({
   badgeFootnote: {
     lineHeight: 18,
     maxWidth: 320,
+  },
+  legalLinksRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.sm,
+    marginTop: spacing.md,
+  },
+  legalLinksSep: {
+    lineHeight: 18,
   },
   footerNote: {
     lineHeight: 18,

--- a/frontend/components/landing/Footer.tsx
+++ b/frontend/components/landing/Footer.tsx
@@ -17,6 +17,9 @@ export function Footer() {
           <a href="/terms" className="pb-footer__link">
             Terms of Service
           </a>
+          <a href="/support" className="pb-footer__link">
+            Support
+          </a>
           <a href={`mailto:${LEGAL_SUPPORT_EMAIL}`} className="pb-footer__link">
             {LEGAL_SUPPORT_EMAIL}
           </a>

--- a/frontend/components/landing/LegalDocument.web.tsx
+++ b/frontend/components/landing/LegalDocument.web.tsx
@@ -3,6 +3,7 @@ import { Brand } from './Brand';
 import { Button } from './Button';
 import { Footer } from './Footer';
 import type { LegalDocument } from './legalContent';
+import { LEGAL_SUPPORT_EMAIL } from './legalContent';
 import { GLOBAL_CSS } from './styles';
 
 interface LegalDocumentPageProps {
@@ -16,6 +17,8 @@ export function LegalDocumentPage({
   siblingHref,
   siblingLabel,
 }: LegalDocumentPageProps) {
+  const isSupport = legalDocument.slug === 'support';
+
   return (
     <>
       <Head>
@@ -41,9 +44,25 @@ export function LegalDocumentPage({
                 <a href="/" className="pb-doc__navLink">
                   Home
                 </a>
-                <a href={siblingHref} className="pb-doc__navLink">
-                  {siblingLabel}
-                </a>
+                {isSupport ? (
+                  <>
+                    <a href="/privacy" className="pb-doc__navLink">
+                      Privacy
+                    </a>
+                    <a href="/terms" className="pb-doc__navLink">
+                      Terms
+                    </a>
+                  </>
+                ) : (
+                  <>
+                    <a href="/support" className="pb-doc__navLink">
+                      Support
+                    </a>
+                    <a href={siblingHref} className="pb-doc__navLink">
+                      {siblingLabel}
+                    </a>
+                  </>
+                )}
               </div>
             </div>
 
@@ -76,6 +95,25 @@ export function LegalDocumentPage({
                         ))}
                       </ul>
                     ) : null}
+
+                    {section.contactLines?.length ? (
+                      <ul className="pb-doc__list">
+                        {section.contactLines.map((line) => (
+                          <li key={`${line.lead}-${line.href}`}>
+                            <strong>{line.lead}:</strong>{' '}
+                            <a
+                              href={line.href}
+                              className="pb-doc__contactLink"
+                              {...(line.href.startsWith('http')
+                                ? { target: '_blank', rel: 'noopener noreferrer' }
+                                : {})}
+                            >
+                              {line.text}
+                            </a>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : null}
                   </section>
                 ))}
               </div>
@@ -84,9 +122,15 @@ export function LegalDocumentPage({
                 <Button href="/" variant="ghost" size="md">
                   Back to home
                 </Button>
-                <Button href={siblingHref} size="md">
-                  {siblingLabel}
-                </Button>
+                {isSupport ? (
+                  <Button href={`mailto:${LEGAL_SUPPORT_EMAIL}`} size="md">
+                    Email support
+                  </Button>
+                ) : (
+                  <Button href={siblingHref} size="md">
+                    {siblingLabel}
+                  </Button>
+                )}
               </div>
             </article>
           </div>

--- a/frontend/components/landing/legalContent.ts
+++ b/frontend/components/landing/legalContent.ts
@@ -3,14 +3,26 @@ export const LEGAL_SUPPORT_EMAIL =
 
 export const LEGAL_UPDATED_AT = 'April 20, 2026';
 
+/** Public URLs on the /support page (hardcoded for App Store review). */
+const SUPPORT_PUBLIC_EMAIL = 'support@polybuys.com';
+const SUPPORT_PUBLIC_WEBSITE_HREF = 'https://polybuys.com';
+const SUPPORT_PUBLIC_GITHUB_ISSUES_HREF = 'https://github.com/codebox-calpoly/PolyBuys/issues';
+
+export type LegalContactLine = {
+  lead: string;
+  href: string;
+  text: string;
+};
+
 export type LegalSection = {
   title: string;
   paragraphs?: readonly string[];
   bullets?: readonly string[];
+  contactLines?: readonly LegalContactLine[];
 };
 
 export type LegalDocument = {
-  slug: 'privacy' | 'terms';
+  slug: 'privacy' | 'terms' | 'support';
   eyebrow: string;
   title: string;
   description: string;
@@ -18,6 +30,53 @@ export type LegalDocument = {
   intro: readonly string[];
   sections: readonly LegalSection[];
 };
+
+/** Support information page for App Store review and in-app help links. */
+export function getSupportDocument(): LegalDocument {
+  const contactLines: LegalContactLine[] = [
+    {
+      lead: 'Email',
+      href: `mailto:${SUPPORT_PUBLIC_EMAIL}`,
+      text: SUPPORT_PUBLIC_EMAIL,
+    },
+    {
+      lead: 'Website',
+      href: SUPPORT_PUBLIC_WEBSITE_HREF,
+      text: 'polybuys.com',
+    },
+    {
+      lead: 'GitHub Issues',
+      href: SUPPORT_PUBLIC_GITHUB_ISSUES_HREF,
+      text: 'github.com/codebox-calpoly/PolyBuys',
+    },
+  ];
+
+  return {
+    slug: 'support',
+    eyebrow: 'PolyBuys',
+    title: 'Support',
+    description:
+      'How to get help with the PolyBuys app or website — contact options and response times.',
+    updatedAt: LEGAL_UPDATED_AT,
+    intro: [
+      'PolyBuys — operated by the PolyBuys student team.',
+      'PolyBuys is an independent marketplace for verified Cal Poly students and is not affiliated with California Polytechnic State University.',
+    ],
+    sections: [
+      {
+        title: 'How to Get Help',
+        paragraphs: [
+          "If you're running into an issue with the app or have a question, you can reach us through any of the following:",
+        ],
+        contactLines,
+      },
+      {
+        title: 'Response time',
+        paragraphs: ["We're a small team, so please allow 1–3 business days for a response."],
+      },
+    ],
+  };
+}
 
 export const PRIVACY_POLICY_DOC: LegalDocument = {
   slug: 'privacy',

--- a/frontend/components/landing/styles.ts
+++ b/frontend/components/landing/styles.ts
@@ -784,6 +784,15 @@ img { max-width: 100%; display: block; }
   line-height: 1.65;
   color: var(--pb-ink);
 }
+.pb-doc__contactLink {
+  color: var(--pb-green);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.pb-doc__contactLink:hover {
+  color: var(--pb-green-2);
+}
 .pb-doc__actions {
   margin-top: 12px;
   display: flex;


### PR DESCRIPTION
- Introduced a new support page for user assistance, accessible via /support.
- Updated LandingScreen to include a link to the support page and added legal links for Privacy and Terms.
- Enhanced the footer to include a link to the support page.
- Implemented support document retrieval with contact options for user inquiries.
- Adjusted styles for legal links and contact information display.

## Linked Issues

Closes #<issue-number>
Linear: <linear-issue-key> (e.g., POLY-123)

## Summary

Briefly explain the change and why.

## How to Test

Steps to verify locally:

- `npm run lint`
- `npm run typecheck`
- `npm test`
- Manual flow:
  1. `npm run dev:backend` (in terminal A)
  2. `npm run dev` (in terminal B)
  3. Verify the change: <describe expected behavior/screens>

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Lint/tests pass locally (`npm run lint`)
- [ ] Docs updated (README/ADR/changelog if needed)
- [ ] Follows conventional commit format
- [ ] No merge conflicts with `dev`

## Screenshots / Demos

(if UI or visible behavior - attach images, videos, or GIFs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Support page with contact information and resources for getting help
  * Added navigation links to Support, Privacy, and Terms pages on the landing screen (web)
  * Added Support link to the footer navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->