### PR TITLE
Allow guest browsing in native app

### DIFF
--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -7,6 +7,7 @@ import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { TextInput } from 'react-native';
 import { useAuth } from '../../hooks/useAuth';
+import { getSignedOutFallback, getVisibleNativeTabs } from '../../lib/navigation/guestAccess';
 import { borderRadius, colors, spacing, typography } from '../../theme/tokens';
 import { nativeChrome } from '../../theme/nativeChrome';
 
@@ -96,7 +97,9 @@ function WebHeaderLayout() {
 
 export default function TabsLayout() {
   const isWeb = Platform.OS === 'web';
-  const { isAuthenticated } = useAuth();
+  const pathname = usePathname();
+  const router = useRouter();
+  const { isAuthenticated, isSessionLoading } = useAuth();
   const conversations = useQuery(
     api.messages.listUserConversations,
     isAuthenticated && !isWeb ? {} : 'skip'
@@ -108,11 +111,26 @@ export default function TabsLayout() {
       0
     ) ?? 0;
 
+  useEffect(() => {
+    if (isWeb || isSessionLoading || isAuthenticated) {
+      return;
+    }
+
+    const fallback = getSignedOutFallback(pathname);
+    if (fallback) {
+      router.replace(fallback as never);
+    }
+  }, [isAuthenticated, isSessionLoading, isWeb, pathname, router]);
+
   if (isWeb) {
     return <WebHeaderLayout />;
   }
 
   const tabTint = nativeChrome.tabIconSelectedColor;
+  const visibleTabs = getVisibleNativeTabs(isAuthenticated);
+  const showMyListings = visibleTabs.includes('my-listings');
+  const showInbox = visibleTabs.includes('inbox');
+  const showSettings = visibleTabs.includes('settings');
 
   const nativeTabs = (
     <NativeTabs
@@ -155,50 +173,56 @@ export default function TabsLayout() {
           md="search"
         />
       </NativeTabs.Trigger>
-      <NativeTabs.Trigger
-        name="my-listings"
-        disableTransparentOnScrollEdge
-        contentStyle={styles.nativeTabContent}
-      >
-        {/* NativeTabs expects plain text inside Trigger.Label. */}
-        {/* eslint-disable-next-line react-native/no-raw-text */}
-        <NativeTabs.Trigger.Label>My Listings</NativeTabs.Trigger.Label>
-        <NativeTabs.Trigger.Icon
-          sf={{ default: 'list.bullet.rectangle', selected: 'list.bullet.rectangle.fill' }}
-          md="view_list"
-        />
-      </NativeTabs.Trigger>
-      <NativeTabs.Trigger
-        name="inbox"
-        disableTransparentOnScrollEdge
-        contentStyle={styles.nativeTabContent}
-      >
-        {/* NativeTabs expects plain text inside Trigger.Label. */}
-        {/* eslint-disable-next-line react-native/no-raw-text */}
-        <NativeTabs.Trigger.Label>Inbox</NativeTabs.Trigger.Label>
-        <NativeTabs.Trigger.Icon
-          sf={{ default: 'bubble.left', selected: 'bubble.left.fill' }}
-          md="chat"
-        />
-        {unreadCount > 0 ? (
-          <NativeTabs.Trigger.Badge>
-            {unreadCount > 9 ? '9+' : String(unreadCount)}
-          </NativeTabs.Trigger.Badge>
-        ) : null}
-      </NativeTabs.Trigger>
-      <NativeTabs.Trigger
-        name="settings"
-        disableTransparentOnScrollEdge
-        contentStyle={styles.nativeTabContent}
-      >
-        {/* NativeTabs expects plain text inside Trigger.Label. */}
-        {/* eslint-disable-next-line react-native/no-raw-text */}
-        <NativeTabs.Trigger.Label>Profile</NativeTabs.Trigger.Label>
-        <NativeTabs.Trigger.Icon
-          sf={{ default: 'person.circle', selected: 'person.circle.fill' }}
-          md="settings"
-        />
-      </NativeTabs.Trigger>
+      {showMyListings ? (
+        <NativeTabs.Trigger
+          name="my-listings"
+          disableTransparentOnScrollEdge
+          contentStyle={styles.nativeTabContent}
+        >
+          {/* NativeTabs expects plain text inside Trigger.Label. */}
+          {/* eslint-disable-next-line react-native/no-raw-text */}
+          <NativeTabs.Trigger.Label>My Listings</NativeTabs.Trigger.Label>
+          <NativeTabs.Trigger.Icon
+            sf={{ default: 'list.bullet.rectangle', selected: 'list.bullet.rectangle.fill' }}
+            md="view_list"
+          />
+        </NativeTabs.Trigger>
+      ) : null}
+      {showInbox ? (
+        <NativeTabs.Trigger
+          name="inbox"
+          disableTransparentOnScrollEdge
+          contentStyle={styles.nativeTabContent}
+        >
+          {/* NativeTabs expects plain text inside Trigger.Label. */}
+          {/* eslint-disable-next-line react-native/no-raw-text */}
+          <NativeTabs.Trigger.Label>Inbox</NativeTabs.Trigger.Label>
+          <NativeTabs.Trigger.Icon
+            sf={{ default: 'bubble.left', selected: 'bubble.left.fill' }}
+            md="chat"
+          />
+          {unreadCount > 0 ? (
+            <NativeTabs.Trigger.Badge>
+              {unreadCount > 9 ? '9+' : String(unreadCount)}
+            </NativeTabs.Trigger.Badge>
+          ) : null}
+        </NativeTabs.Trigger>
+      ) : null}
+      {showSettings ? (
+        <NativeTabs.Trigger
+          name="settings"
+          disableTransparentOnScrollEdge
+          contentStyle={styles.nativeTabContent}
+        >
+          {/* NativeTabs expects plain text inside Trigger.Label. */}
+          {/* eslint-disable-next-line react-native/no-raw-text */}
+          <NativeTabs.Trigger.Label>Profile</NativeTabs.Trigger.Label>
+          <NativeTabs.Trigger.Icon
+            sf={{ default: 'person.circle', selected: 'person.circle.fill' }}
+            md="settings"
+          />
+        </NativeTabs.Trigger>
+      ) : null}
     </NativeTabs>
   );
 

--- a/frontend/app/(tabs)/home.tsx
+++ b/frontend/app/(tabs)/home.tsx
@@ -290,12 +290,19 @@ export default function HomeScreen() {
     if (!isAuthenticated) {
       Alert.alert('Sign In Required', 'Please sign in to create a listing', [
         { text: 'Cancel', style: 'cancel' },
-        { text: 'Sign In', onPress: () => router.replace('/auth/login') },
+        {
+          text: 'Sign In',
+          onPress: () => router.replace('/auth/login?returnTo=%2Fhome' as never),
+        },
       ]);
       return;
     }
     router.push('/listings/new');
   };
+
+  const handleBrowseSignIn = useCallback(() => {
+    router.replace('/auth/login?returnTo=%2Fhome' as never);
+  }, [router]);
 
   const isCompactLayout = width < 760;
   const webScrollHorizontalPadding = isDesktopWeb ? spacing.xl : width >= 900 ? spacing.lg : 10;
@@ -528,16 +535,22 @@ export default function HomeScreen() {
         >
           <ScreenHeader
             title="Browse"
-            subtitle="Fresh listings from campus"
+            subtitle={
+              isAuthenticated
+                ? 'Fresh listings from campus'
+                : 'Browse as guest. Sign in to save listings, message sellers, and post items.'
+            }
             action={
               <Pressable
                 style={({ pressed }) => [styles.createChip, pressed && styles.createChipPressed]}
-                onPress={handleCreateListing}
+                onPress={isAuthenticated ? handleCreateListing : handleBrowseSignIn}
                 disabled={isSessionLoading}
-                accessibilityLabel="Create listing"
+                accessibilityLabel={isAuthenticated ? 'Create listing' : 'Sign in'}
                 accessibilityRole="button"
               >
-                <Text style={styles.createChipText}>+ Create</Text>
+                <Text style={styles.createChipText}>
+                  {isAuthenticated ? '+ Create' : 'Sign In'}
+                </Text>
               </Pressable>
             }
           />

--- a/frontend/app/(tabs)/inbox.tsx
+++ b/frontend/app/(tabs)/inbox.tsx
@@ -23,6 +23,7 @@ import { api } from 'convex/_generated/api';
 import { Id } from 'convex/_generated/dataModel';
 import { useEntranceAnimation } from '../../hooks/useEntranceAnimation';
 import { useAuth } from '../../hooks/useAuth';
+import { getSignedOutFallback } from '../../lib/navigation/guestAccess';
 import { useResolvedImageUrls } from '../../hooks/useResolvedImageUrls';
 import ProfileAvatar from '../../components/ProfileAvatar';
 import { ScreenState } from '../../components/ScreenState';
@@ -398,7 +399,7 @@ export default function InboxScreen() {
 
   useEffect(() => {
     if (!isWeb && !isSessionLoading && !isAuthenticated) {
-      router.replace('/auth/login?returnTo=%2Finbox' as never);
+      router.replace((getSignedOutFallback('/inbox') ?? '/home') as never);
     }
   }, [isSessionLoading, isAuthenticated, isWeb, router]);
 

--- a/frontend/app/(tabs)/my-listings.tsx
+++ b/frontend/app/(tabs)/my-listings.tsx
@@ -21,6 +21,7 @@ import MyListingActionsSheet, {
   type MyListingActionTarget,
 } from '../../components/MyListingActionsSheet';
 import { useAuth } from '../../hooks/useAuth';
+import { getSignedOutFallback } from '../../lib/navigation/guestAccess';
 import { colors, typography, spacing, borderRadius } from '../../theme/tokens';
 import OpenInAppPrompt from '../../components/OpenInAppPrompt';
 import { FilterChips, ScreenHeader, type FilterChipOption } from '../../components/ui';
@@ -79,7 +80,7 @@ export default function MyListingsScreen() {
 
   useEffect(() => {
     if (!isWeb && !isSessionLoading && !isAuthenticated) {
-      router.replace('/auth/login?returnTo=%2Fmy-listings' as never);
+      router.replace((getSignedOutFallback('/my-listings') ?? '/home') as never);
     }
   }, [isAuthenticated, isSessionLoading, isWeb, router]);
 

--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -20,6 +20,7 @@ import ProfileAvatar from '../../components/ProfileAvatar';
 import { ScreenState } from '../../components/ScreenState';
 import { formatMajorLabel } from '../../constants/calPolyMajors';
 import { FilterChips, ScreenScrollView, type FilterChipOption } from '../../components/ui';
+import { getSignedOutFallback } from '../../lib/navigation/guestAccess';
 import { colors, typography, spacing, borderRadius } from '../../theme/tokens';
 import type { Doc } from 'convex/_generated/dataModel';
 
@@ -71,7 +72,7 @@ export default function SettingsScreen() {
 
   useEffect(() => {
     if (!isWeb && !isSessionLoading && !isAuthenticated) {
-      router.replace('/auth/login' as never);
+      router.replace((getSignedOutFallback('/settings') ?? '/home') as never);
     }
   }, [isAuthenticated, isSessionLoading, isWeb, router]);
 

--- a/frontend/app/account-settings.tsx
+++ b/frontend/app/account-settings.tsx
@@ -21,6 +21,7 @@ import { ScreenState } from '../components/ScreenState';
 import { formatMajorLabel } from '../constants/calPolyMajors';
 import { PRIVACY_POLICY_URL, TERMS_OF_SERVICE_URL } from '../constants/app';
 import { openExternalUrl } from '../utils/openExternalUrl';
+import { getSignedOutFallback } from '../lib/navigation/guestAccess';
 import { getUserFlowErrorMessage } from '../lib/user-flow-errors';
 import { borderRadius, colors, spacing, typography } from '../theme/tokens';
 
@@ -59,7 +60,7 @@ export default function AccountSettingsScreen() {
 
   useEffect(() => {
     if (!isWeb && !isLoading && !isAuthenticated) {
-      router.replace('/auth/login' as never);
+      router.replace((getSignedOutFallback('/account-settings') ?? '/home') as never);
     }
   }, [isAuthenticated, isLoading, isWeb, router]);
 
@@ -71,7 +72,7 @@ export default function AccountSettingsScreen() {
 
   const handleSignOut = async () => {
     if (!isAuthenticated) {
-      router.replace('/auth/login' as never);
+      router.replace((getSignedOutFallback('/account-settings') ?? '/home') as never);
       return;
     }
 

--- a/frontend/app/auth/login.tsx
+++ b/frontend/app/auth/login.tsx
@@ -419,8 +419,8 @@ export default function LoginScreen() {
               <Text style={styles.eyebrow}>PolyBuys</Text>
               <Text style={styles.title}>Welcome</Text>
               <Text style={styles.subtitle}>
-                Buy and sell with fellow Cal Poly students. Sign in with your @calpoly.edu email to
-                get started.
+                Browse listings without an account. Sign in with your @calpoly.edu email to save
+                listings, message sellers, and post items.
               </Text>
               <Pressable
                 style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}

--- a/frontend/lib/navigation/__tests__/guestAccess.test.ts
+++ b/frontend/lib/navigation/__tests__/guestAccess.test.ts
@@ -1,0 +1,29 @@
+import {
+  SIGNED_IN_NATIVE_TABS,
+  SIGNED_OUT_NATIVE_TABS,
+  getSignedOutFallback,
+  getVisibleNativeTabs,
+} from '../guestAccess';
+
+describe('guestAccess', () => {
+  it('returns browse-only tabs for signed-out users', () => {
+    expect(getVisibleNativeTabs(false)).toEqual(SIGNED_OUT_NATIVE_TABS);
+  });
+
+  it('returns all native tabs for signed-in users', () => {
+    expect(getVisibleNativeTabs(true)).toEqual(SIGNED_IN_NATIVE_TABS);
+  });
+
+  it('redirects protected account routes back to home when signed out', () => {
+    expect(getSignedOutFallback('/my-listings')).toBe('/home');
+    expect(getSignedOutFallback('/inbox')).toBe('/home');
+    expect(getSignedOutFallback('/settings')).toBe('/home');
+    expect(getSignedOutFallback('/account-settings')).toBe('/home');
+  });
+
+  it('leaves public browse routes accessible', () => {
+    expect(getSignedOutFallback('/home')).toBeNull();
+    expect(getSignedOutFallback('/search')).toBeNull();
+    expect(getSignedOutFallback('/listings/abc123')).toBeNull();
+  });
+});

--- a/frontend/lib/navigation/guestAccess.ts
+++ b/frontend/lib/navigation/guestAccess.ts
@@ -1,0 +1,26 @@
+export const SIGNED_OUT_NATIVE_TABS = ['home', 'search'] as const;
+
+export const SIGNED_IN_NATIVE_TABS = [
+  'home',
+  'search',
+  'my-listings',
+  'inbox',
+  'settings',
+] as const;
+
+const SIGNED_OUT_FALLBACK_ROUTES = new Set([
+  '/my-listings',
+  '/inbox',
+  '/settings',
+  '/account-settings',
+]);
+
+export type NativeTabName = (typeof SIGNED_IN_NATIVE_TABS)[number];
+
+export function getVisibleNativeTabs(isAuthenticated: boolean): readonly NativeTabName[] {
+  return isAuthenticated ? SIGNED_IN_NATIVE_TABS : SIGNED_OUT_NATIVE_TABS;
+}
+
+export function getSignedOutFallback(pathname: string): '/home' | null {
+  return SIGNED_OUT_FALLBACK_ROUTES.has(pathname) ? '/home' : null;
+}


### PR DESCRIPTION
## Linked Issues

Closes: none
Linear: none

## Summary

Allows signed-out native users to browse Home, Search, and listing detail without registering while keeping save, message, post, and account flows behind login. Hides account-only tabs for guests, redirects signed-out access to protected tab routes back to Home, and updates the guest-facing Home and login copy. Adds a small `guestAccess` helper with unit coverage for tab visibility and fallback behavior.

## How to Test

Steps to verify locally:

- `npm run lint`
- `npm run typecheck`
- `npm test`
- Manual flow:
  1. `npm run dev:backend` (in terminal A)
  2. `npm run dev` (in terminal B)
  3. Verify signed-out users land on Home, only see Home/Search tabs, can browse listings/search/detail without login, and are prompted to sign in only for save, message, create-listing, inbox, profile, and settings actions.

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Lint/tests pass locally (`npm run lint`)
- [ ] Docs updated (README/ADR/changelog if needed)
- [x] Follows conventional commit format
- [x] No merge conflicts with `dev`

## Screenshots / Demos

UI change; no screenshots attached.
