### PR TITLE
fix: align date with title and price on listing cards

### DIFF
--- a/frontend/components/ListingCard.tsx
+++ b/frontend/components/ListingCard.tsx
@@ -288,25 +288,26 @@ export default function ListingCard({
               >
                 {listing.title}
               </Text>
+              <View style={styles.conditionPill}>
+                <Text style={styles.conditionPillText} numberOfLines={1}>
+                  {conditionLabel}
+                </Text>
+              </View>
+            </View>
+            <View style={styles.priceRow}>
               <Text
-                style={[styles.listingCondition, isHomeDensity && styles.listingConditionHome]}
+                style={[styles.listingPrice, isHomeDensity && styles.listingPriceHome]}
                 numberOfLines={1}
               >
-                {conditionLabel}
+                ${formatPrice(listing.price)}
               </Text>
+              {(listing.postedOn || listing.createdAt) && (
+                <Text style={styles.listingDate} numberOfLines={1}>
+                  {formatRelativeDate(listing.postedOn ?? listing.createdAt!)}
+                </Text>
+              )}
             </View>
-            <Text
-              style={[styles.listingPrice, isHomeDensity && styles.listingPriceHome]}
-              numberOfLines={1}
-            >
-              ${formatPrice(listing.price)}
-            </Text>
           </View>
-          {(listing.postedOn || listing.createdAt) && (
-            <Text style={[styles.listingDate, isHomeDensity && styles.listingDateHome]}>
-              {formatRelativeDate(listing.postedOn ?? listing.createdAt!)}
-            </Text>
-          )}
         </Pressable>
         {onToggleSave || onManagePress ? (
           <View style={styles.floatingActions} pointerEvents="box-none">
@@ -503,12 +504,12 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.smPlus,
     paddingTop: spacing.sm,
     paddingBottom: spacing.md,
-    gap: 2,
+    gap: spacing.xs,
   },
   titleRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: spacing.xs,
+    gap: spacing.sm,
   },
   listingTitle: {
     ...typography.subhead,
@@ -524,35 +525,43 @@ const styles = StyleSheet.create({
     lineHeight: 20,
     fontWeight: '600',
   },
-  listingCondition: {
-    ...typography.footnote,
+  conditionPill: {
     flexShrink: 0,
-    color: colors.gray,
-    fontWeight: '500',
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: borderRadius.full,
+    backgroundColor: colors.border,
   },
-  listingConditionHome: {
-    fontSize: 12,
+  conditionPillText: {
+    ...typography.footnote,
+    fontSize: 11,
+    lineHeight: 14,
+    fontWeight: '600',
+    letterSpacing: 0.3,
+    color: colors.primary,
+  },
+  priceRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
   },
   listingPrice: {
     ...typography.title2,
+    flexShrink: 1,
+    minWidth: 0,
     fontSize: 18,
     fontWeight: '700',
     color: colors.accent,
-    marginTop: spacing.xs,
   },
   listingPriceHome: {
     fontSize: 17,
-    marginTop: spacing.xs,
   },
   listingDate: {
     ...typography.footnote,
+    flexShrink: 0,
+    fontSize: 12,
     color: colors.muted,
-    paddingHorizontal: spacing.sm,
-    paddingBottom: spacing.sm,
-  },
-  listingDateHome: {
-    paddingHorizontal: spacing.sm,
-    paddingBottom: spacing.md,
   },
   footer: {
     marginTop: spacing.sm,


### PR DESCRIPTION
## Summary

The posted-date on listing cards was rendered outside the `cardDetails` container with its own horizontal padding (`spacing.sm`), while the title and price used `cardDetails`'s `spacing.md`. That 4px difference made the date drift left of the title/price. This moves the date inside `cardDetails` on the same row as the price (right-aligned, baseline-aligned), so all three share one container's padding and stay aligned by construction. Also polishes the condition label ("Used", "New") from plain gray text into a subtle rounded pill.

## How to Test

- \`npm run lint\`
- \`npm run typecheck\`
- Manual: open the Browse tab in the native app and confirm the title, price, and date on each listing card share the same left edge. Also check My Listings, Saved Listings (settings), and profile listing grids.

## Screenshots / Demos

Before: date sat 4px left of the title/price. After: title, price, and date all share the same left edge; condition label is a pill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style

* **Improved listing card layout**: The condition label is now displayed as a rounded pill-shaped badge positioned next to the title. Price and date have been reorganized into a unified row layout, with price displayed on the left and the relative posting date shown on the right.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->