### PR TITLE
[codex] Improve startup loading copy

### DIFF
--- a/frontend/app/(tabs)/home.tsx
+++ b/frontend/app/(tabs)/home.tsx
@@ -330,7 +330,7 @@ export default function HomeScreen() {
               loadError
                 ? "Couldn't load listings"
                 : !hasLoadedOnceRef.current && cursor === null
-                  ? 'Loading listings...'
+                  ? 'Getting the latest listings'
                   : hasSearchQuery
                     ? 'No listings found'
                     : hasActiveFilters
@@ -341,7 +341,7 @@ export default function HomeScreen() {
               loadError
                 ? 'Check your connection and try again.'
                 : !hasLoadedOnceRef.current && cursor === null
-                  ? undefined
+                  ? 'Pulling in fresh items from campus.'
                   : hasSearchQuery
                     ? `Nothing matched "${searchQuery}". Try a different search or fewer filters.`
                     : hasActiveFilters
@@ -466,18 +466,7 @@ export default function HomeScreen() {
             />
           ) : null}
 
-          {!hasLoadedOnceRef.current && listingsResult === undefined && cursor === null ? (
-            <View style={styles.centerContainer}>
-              <View style={styles.stateCard}>
-                <ScreenState
-                  variant={loadError ? 'error' : 'loading'}
-                  title={loadError ? "Couldn't load listings" : 'Loading listings...'}
-                  message={loadError ? 'Check your connection and try again.' : undefined}
-                  onRetry={loadError ? refreshListings : undefined}
-                />
-              </View>
-            </View>
-          ) : listings.length === 0 ? (
+          {listings.length === 0 ? (
             listEmptyComponent
           ) : (
             <>
@@ -588,61 +577,46 @@ export default function HomeScreen() {
           onClose={() => setShowSortPicker(false)}
         />
 
-        {!hasLoadedOnceRef.current && listingsResult === undefined && cursor === null ? (
-          <View
-            style={[styles.centerContainer, { paddingHorizontal: nativeListHorizontalPadding }]}
-          >
-            <View style={styles.stateCard}>
-              <ScreenState
-                variant={loadError ? 'error' : 'loading'}
-                title={loadError ? "Couldn't load listings" : 'Loading listings...'}
-                message={loadError ? 'Check your connection and try again.' : undefined}
-                onRetry={loadError ? refreshListings : undefined}
-              />
-            </View>
-          </View>
-        ) : (
-          <FlatList
-            key={`home-${homeColumns}`}
-            data={listings}
-            keyExtractor={(item) => item._id}
-            renderItem={({ item, index }) => (
-              <ListingCard
-                listing={item}
-                index={index}
-                isSaved={savedState?.[item._id] ?? false}
-                onToggleSave={() => void handleToggleSave(item._id as Id<'listings'>)}
-                shellStyle="flat"
-              />
-            )}
-            numColumns={homeColumns}
-            columnWrapperStyle={
-              homeColumns > 1
-                ? [styles.columnWrapper, isCompactLayout && styles.columnWrapperCompact]
-                : undefined
-            }
-            contentContainerStyle={[
-              styles.listContainer,
-              isDesktopWeb && styles.listContainerDesktop,
-              {
-                paddingBottom: Math.max(insets.bottom + 60, 80),
-                paddingHorizontal: nativeListHorizontalPadding,
-              },
-            ]}
-            onEndReached={handleLoadMore}
-            onEndReachedThreshold={0.5}
-            refreshControl={
-              <RefreshControl
-                refreshing={refreshing}
-                onRefresh={handleRefresh}
-                colors={[colors.primary]}
-                tintColor={colors.primary}
-              />
-            }
-            ListEmptyComponent={listEmptyComponent}
-            ListFooterComponent={listFooterComponent}
-          />
-        )}
+        <FlatList
+          key={`home-${homeColumns}`}
+          data={listings}
+          keyExtractor={(item) => item._id}
+          renderItem={({ item, index }) => (
+            <ListingCard
+              listing={item}
+              index={index}
+              isSaved={savedState?.[item._id] ?? false}
+              onToggleSave={() => void handleToggleSave(item._id as Id<'listings'>)}
+              shellStyle="flat"
+            />
+          )}
+          numColumns={homeColumns}
+          columnWrapperStyle={
+            homeColumns > 1
+              ? [styles.columnWrapper, isCompactLayout && styles.columnWrapperCompact]
+              : undefined
+          }
+          contentContainerStyle={[
+            styles.listContainer,
+            isDesktopWeb && styles.listContainerDesktop,
+            {
+              paddingBottom: Math.max(insets.bottom + 60, 80),
+              paddingHorizontal: nativeListHorizontalPadding,
+            },
+          ]}
+          onEndReached={handleLoadMore}
+          onEndReachedThreshold={0.5}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={handleRefresh}
+              colors={[colors.primary]}
+              tintColor={colors.primary}
+            />
+          }
+          ListEmptyComponent={listEmptyComponent}
+          ListFooterComponent={listFooterComponent}
+        />
       </View>
     </View>
   );
@@ -755,13 +729,6 @@ const styles = StyleSheet.create({
   },
   columnWrapperCompact: {
     gap: spacing.xs,
-  },
-  centerContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingTop: spacing.xxl,
-    paddingHorizontal: spacing.xl,
   },
   stateContainer: {
     flex: 1,

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -1,8 +1,8 @@
 import { Redirect } from 'expo-router';
-import { ActivityIndicator, Platform, StyleSheet, View } from 'react-native';
+import { Platform } from 'react-native';
 import LandingScreen from '../components/LandingScreen';
+import { ScreenState } from '../components/ScreenState';
 import { useAuth } from '../hooks/useAuth';
-import { colors } from '../theme/tokens';
 
 export default function IndexRoute() {
   const { isAuthenticated, isLoading } = useAuth();
@@ -13,9 +13,7 @@ export default function IndexRoute() {
 
   if (isLoading) {
     return (
-      <View style={styles.boot}>
-        <ActivityIndicator size="large" color={colors.primary} accessibilityLabel="Loading" />
-      </View>
+      <ScreenState variant="loading" title="Opening PolyBuys" message="Checking your session." />
     );
   }
 
@@ -25,12 +23,3 @@ export default function IndexRoute() {
 
   return <LandingScreen />;
 }
-
-const styles = StyleSheet.create({
-  boot: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: colors.background,
-  },
-});


### PR DESCRIPTION
## Linked Issues

Closes: none
Linear: N/A

## Summary

Refines the startup loading experience without adding extra UI chrome. The root route now uses the shared loading state, and the listings screen copy is more intentional during the initial fetch.

## How to Test

Steps to verify locally:

- `npm run typecheck`
- Manual flow:
  1. `npm run dev`
  2. Open the app and verify the initial loading states read `Opening PolyBuys` and `Getting the latest listings` with the updated supporting copy.

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Lint/tests pass locally (`npm run lint`)
- [ ] Docs updated (README/ADR/changelog if needed)
- [x] Follows conventional commit format
- [ ] No merge conflicts with `dev`

## Screenshots / Demos

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated loading messages with more engaging, descriptive text throughout the app.
  * Simplified loading state display presentation for improved user experience.

* **Refactor**
  * Streamlined loading UI component architecture and removed redundant styling infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->