### PR TITLE
ci: gate iOS release workflows behind manual dispatch and version checks

### DIFF
--- a/.github/workflows/ios-release-dev.yml
+++ b/.github/workflows/ios-release-dev.yml
@@ -1,4 +1,4 @@
-name: iOS TestFlight (manual)
+name: iOS TestFlight (dev)
 
 on:
   workflow_dispatch:
@@ -14,6 +14,13 @@ jobs:
     timeout-minutes: 90
 
     steps:
+      - name: Ensure dev branch
+        run: |
+          if [ "${GITHUB_REF}" != "refs/heads/dev" ]; then
+            echo "::error title=Wrong branch::Run this workflow from the dev branch."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v5
 
@@ -27,6 +34,12 @@ jobs:
         with:
           node-version: '20.19.4'
           cache: 'npm'
+
+      - name: Print TestFlight version
+        working-directory: frontend
+        run: |
+          APP_VERSION=$(node -p "require('./app.json').expo.version")
+          echo "::notice title=iOS TestFlight version::Building a dev TestFlight candidate for iOS version $APP_VERSION."
 
       - name: Setup Expo and EAS
         uses: expo/expo-github-action@v8

--- a/.github/workflows/ios-release-main.yml
+++ b/.github/workflows/ios-release-main.yml
@@ -1,20 +1,12 @@
-name: iOS TestFlight (main)
+name: iOS Release Candidate (main)
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - 'backend/**'
-      - 'convex/**'
-      - 'docs/**'
-      - '**.md'
-      - 'scripts/**'
-      - 'vercel.json'
-      - '.github/workflows/ci.yml'
-      - '.github/workflows/ios-release-dev.yml'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.coderabbit.yaml'
-      - 'LICENSE'
+  workflow_dispatch:
+    inputs:
+      app_version:
+        description: 'Version from frontend/app.json to release, for example 1.0.1'
+        required: true
+        type: string
 
 concurrency:
   group: ios-release-main
@@ -27,6 +19,13 @@ jobs:
     timeout-minutes: 90
 
     steps:
+      - name: Ensure main branch
+        run: |
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "::error title=Wrong branch::Run this workflow from the main branch."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v5
 
@@ -40,6 +39,18 @@ jobs:
         with:
           node-version: '20.19.4'
           cache: 'npm'
+
+      - name: Validate release version
+        working-directory: frontend
+        env:
+          EXPECTED_APP_VERSION: ${{ inputs.app_version }}
+        run: |
+          APP_VERSION=$(node -p "require('./app.json').expo.version")
+          if [ "$APP_VERSION" != "$EXPECTED_APP_VERSION" ]; then
+            echo "::error title=Version mismatch::frontend/app.json has version $APP_VERSION but the workflow input was $EXPECTED_APP_VERSION."
+            exit 1
+          fi
+          echo "::notice title=iOS release version::Uploading iOS version $APP_VERSION to TestFlight. App Store review must still be started in App Store Connect."
 
       - name: Setup Expo and EAS
         uses: expo/expo-github-action@v8
@@ -60,7 +71,7 @@ jobs:
           CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
         run: npx convex deploy
 
-      - name: Submit to TestFlight
+      - name: Submit release candidate to TestFlight
         working-directory: frontend
         run: eas submit --platform ios --profile production --path ${{ github.workspace }}/build.ipa --non-interactive
 

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "PolyBuys",
     "slug": "polybuy",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "portrait",
     "userInterfaceStyle": "light",
     "platforms": ["ios", "android", "web"],


### PR DESCRIPTION
## Summary

The main iOS workflow now triggers via `workflow_dispatch` with a required `app_version` input that must match `frontend/app.json`, replacing the prior automatic push trigger so releases are deliberate. The dev workflow is renamed to "iOS TestFlight (dev)" for clarity, and both workflows gain fail-fast branch guards (placed before any setup) so a misfire from the wrong branch aborts in seconds rather than after `npm ci`. Also bumps `frontend/app.json` from 1.0.0 to 1.0.1 for the next release.

## How to Test

- Dispatch "iOS TestFlight (dev)" from a non-`dev` branch and confirm it fails immediately with a "Wrong branch" error.
- Dispatch "iOS Release Candidate (main)" from `main` with an `app_version` that does not match `frontend/app.json` and confirm it fails after Node setup with a "Version mismatch" error.
- Dispatch "iOS Release Candidate (main)" from `main` with `app_version=1.0.1` and confirm the build proceeds and submits to TestFlight.

## Checklist

- [x] No merge conflicts with `dev`
- [x] Follows conventional commit format