### PR TITLE
feat: enable multi-photo selection from library on iOS

### DIFF
--- a/frontend/components/ImageUploader.tsx
+++ b/frontend/components/ImageUploader.tsx
@@ -157,28 +157,30 @@ export default function ImageUploader({
     });
   }
 
-  async function pickFromLibrary() {
+  async function pickFromLibrary(remainingSlots: number): Promise<PickedImage[]> {
     const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
     if (!permission.granted) {
       Alert.alert('Permission required', 'Please allow access to your photo library.');
-      return null;
+      return [];
     }
 
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ['images'],
       quality: 1,
       allowsEditing: false,
+      allowsMultipleSelection: true,
+      selectionLimit: remainingSlots,
     });
 
-    if (result.canceled) {
-      return null;
+    if (result.canceled || result.assets.length === 0) {
+      return [];
     }
 
-    return {
-      uri: result.assets[0].uri,
-      width: result.assets[0].width,
-      height: result.assets[0].height,
-    };
+    return result.assets.map((asset) => ({
+      uri: asset.uri,
+      width: asset.width,
+      height: asset.height,
+    }));
   }
 
   async function pickFromCamera() {
@@ -421,6 +423,20 @@ export default function ImageUploader({
     await startUpload(picked, localId);
   }
 
+  async function handlePickAndUploadMultiple(pickedImages: PickedImage[]) {
+    if (pickedImages.length === 0) {
+      return;
+    }
+    const newPending: PendingUpload[] = pickedImages.map((img, i) => ({
+      localId: `pending-${Date.now()}-${i}`,
+      uri: img.uri,
+      progress: 0,
+      status: 'uploading' as UploadStatus,
+    }));
+    setPendingUploads((prev) => [...prev, ...newPending]);
+    await Promise.all(pickedImages.map((img, i) => startUpload(img, newPending[i].localId)));
+  }
+
   async function addImage() {
     if (images.length + pendingUploads.length >= maxImages) {
       Alert.alert('Maximum reached', `You can only upload up to ${maxImages} images.`);
@@ -450,6 +466,8 @@ export default function ImageUploader({
       return;
     }
 
+    const remainingSlots = maxImages - images.length - pendingUploads.length;
+
     Alert.alert('Add image', 'Choose image source', [
       {
         text: 'Camera',
@@ -463,7 +481,8 @@ export default function ImageUploader({
         text: 'Photo Library',
         onPress: () => {
           void (async () => {
-            await handlePickAndUpload(pickFromLibrary);
+            const picked = await pickFromLibrary(remainingSlots);
+            await handlePickAndUploadMultiple(picked);
           })();
         },
       },


### PR DESCRIPTION
## Summary

When adding photos to a listing on iOS, users could only select **one photo at a time** from their camera roll. This PR enables multi-select so users can pick multiple photos in a single interaction.

## Changes

- **`pickFromLibrary()`** — Added `allowsMultipleSelection: true` and `selectionLimit` (set to remaining available slots) to `expo-image-picker`'s `launchImageLibraryAsync()`. Now returns `PickedImage[]` instead of a single image.
- **New `handlePickAndUploadMultiple()`** — Accepts an array of picked images, creates pending upload entries for all of them, and kicks off all uploads in parallel via `Promise.all`.
- **`addImage()`** — Calculates `remainingSlots` and routes the "Photo Library" option through the new multi-upload flow. Camera still picks a single photo (hardware limitation).

## Testing

- Typecheck passes (no new errors)
- Lint + Prettier pass via pre-commit hook
- On iOS, the native photo picker now shows checkmarks for multi-select, capped at the remaining available slots (up to 8 total)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * **Batch photo uploads**: Users can now select and upload multiple images from their photo library in a single interaction. Selected photos are processed concurrently for improved efficiency, eliminating the need to add images individually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->